### PR TITLE
Update CodeQL workflow for Swift analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,9 +32,9 @@ jobs:
           languages: swift
 
       - name: Build
+        working-directory: MixpanelSessionReplay
         run: |
           xcodebuild clean build \
-            -project MixpanelSessionReplay/MixpanelSessionReplay.xcodeproj \
             -scheme MixpanelSessionReplay \
             -destination 'generic/platform=iOS' \
             CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze (swift)
-    runs-on: macos-latest
+    runs-on: macos-26
     permissions:
       security-events: write
       actions: read
@@ -19,13 +19,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Select Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1
+        with:
+          xcode-version: '26.2'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@<SHA>  # v3.x.x
         with:
           languages: swift
 
@@ -38,6 +40,6 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@<SHA>  # v3.x.x
         with:
           category: "/language:swift"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
           xcode-version: '26.2'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8f596fcc91a271190fbe5f52d37d65fa5c60c904  # v3.28.0
+        uses: github/codeql-action/init@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169  # v3.28.0
         with:
           languages: swift
 
@@ -40,6 +40,6 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8f596fcc91a271190fbe5f52d37d65fa5c60c904  # v3.28.0
+        uses: github/codeql-action/analyze@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169  # v3.28.0
         with:
           category: "/language:swift"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
           xcode-version: '26.2'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@<SHA>  # v3.x.x
+        uses: github/codeql-action/init@8f596fcc91a271190fbe5f52d37d65fa5c60c904  # v3.28.0
         with:
           languages: swift
 
@@ -40,6 +40,6 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@<SHA>  # v3.x.x
+        uses: github/codeql-action/analyze@8f596fcc91a271190fbe5f52d37d65fa5c60c904  # v3.28.0
         with:
           category: "/language:swift"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (swift)
+    runs-on: macos-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: swift
+
+      - name: Build
+        run: |
+          xcodebuild clean build \
+            -project MixpanelSessionReplay/MixpanelSessionReplay.xcodeproj \
+            -scheme MixpanelSessionReplay \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:swift"


### PR DESCRIPTION
## Add CodeQL Advanced Setup for GHAS Code Scanning

This PR adds a CodeQL workflow to enable GitHub Advanced Security code scanning for this repository.

### Why advanced setup instead of default

CodeQL's default setup was previously configured on this repo but failed to produce results. Investigation revealed two issues:

- The Swift/Objective-C analysis failed because default setup cannot automatically build an Xcode project without knowing the scheme, project path, and build configuration
- The Ruby analysis failed because CodeQL found no Ruby source code in the repo — only GitHub Actions YAML, Swift, and Objective-C. Default setup has no mechanism to handle either of these without a custom workflow

### Why Ruby is not included

CodeQL detected Ruby as a candidate language likely due to tooling files (Gemfile, CocoaPods), but there is no substantive Ruby source code in this repository. Including Ruby in the matrix produces a fatal finalization error and no useful results. It has been omitted intentionally.

### What this workflow does

On every push to `main`, every pull request targeting `main`, and on a weekly schedule, this workflow:

1. Checks out the repository
2. Initializes CodeQL for Swift
3. Builds the SDK using `xcodebuild` against the `MixpanelSessionReplay` scheme with code signing disabled
4. Uploads results to the repository Security tab

Both Swift and Objective-C are covered under the `swift` language pack.

### Expected outcome

The code scanning configuration error on the Security Overview should resolve once this workflow runs successfully. Going forward, CodeQL findings will appear in the Security tab and will be reported on pull requests.


<img width="1849" height="334" alt="image" src="https://github.com/user-attachments/assets/31f5bdf4-991a-4083-8c73-d5485de0bc4b" />

<img width="1449" height="858" alt="image" src="https://github.com/user-attachments/assets/77136694-cae5-4086-8a32-e6867011d28c" />
