### PR TITLE
feat: Add getSessionReplayUrl API to return replay link for active session

### DIFF
--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
@@ -68,8 +68,8 @@ open class MPSessionReplay {
     /// Returns the URL to view the current session replay in the Mixpanel dashboard.
     ///
     /// - Returns: The session replay URL if recording is active, or `nil` if not recording.
-    open class func getSessionReplayUrl() -> String? {
-        return MPSessionReplay.getInstance()?.getSessionReplayUrl()
+    open class func getSessionReplayURL() -> String? {
+        return MPSessionReplay.getInstance()?.getSessionReplayURL()
     }
 }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
@@ -64,6 +64,13 @@ open class MPSessionReplay {
         }
         return nil
     }
+
+    /// Returns the URL to view the current session replay in the Mixpanel dashboard.
+    ///
+    /// - Returns: The session replay URL if recording is active, or `nil` if not recording.
+    open class func getSessionReplayUrl() -> String? {
+        return MPSessionReplay.getInstance()?.getSessionReplayUrl()
+    }
 }
 
 final class MPSessionReplayManager {

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
@@ -286,7 +286,7 @@ open class MPSessionReplayInstance: MPSessionReplaying {
     /// Returns the URL to view the current session replay in the Mixpanel dashboard.
     ///
     /// - Returns: The session replay URL if recording is active, or `nil` if not recording.
-    public func getSessionReplayUrl() -> String? {
+    public func getSessionReplayURL() -> String? {
         guard isRecording else { return nil }
         var components = URLComponents(string: EndPoints.sessionReplayRedirect)
         components?.queryItems = [

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
@@ -294,7 +294,9 @@ open class MPSessionReplayInstance: MPSessionReplaying {
             URLQueryItem(name: "distinct_id", value: flushService.getDistinctId()),
             URLQueryItem(name: "token", value: token),
         ]
-        return components?.string
+        components?.percentEncodedQuery = components?.percentEncodedQuery?.replacingOccurrences(
+            of: "+", with: "%2B")
+        return components?.url?.absoluteString
     }
 
     func record(_ triggerTimestamp: Int64? = nil) {

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
@@ -294,8 +294,9 @@ open class MPSessionReplayInstance: MPSessionReplaying {
             URLQueryItem(name: "distinct_id", value: flushService.getDistinctId()),
             URLQueryItem(name: "token", value: token),
         ]
-        components?.percentEncodedQuery = components?.percentEncodedQuery?.replacingOccurrences(
-            of: "+", with: "%2B")
+        if let encodedQuery = components?.percentEncodedQuery {
+            components?.percentEncodedQuery = encodedQuery.replacingOccurrences(of: "+", with: "%2B")
+        }
         return components?.url?.absoluteString
     }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
@@ -283,6 +283,20 @@ open class MPSessionReplayInstance: MPSessionReplaying {
             })
     }
 
+    /// Returns the URL to view the current session replay in the Mixpanel dashboard.
+    ///
+    /// - Returns: The session replay URL if recording is active, or `nil` if not recording.
+    public func getSessionReplayUrl() -> String? {
+        guard isRecording else { return nil }
+        var components = URLComponents(string: EndPoints.sessionReplayRedirect)
+        components?.queryItems = [
+            URLQueryItem(name: "replay_id", value: SessionManager.shared.replayId),
+            URLQueryItem(name: "distinct_id", value: flushService.getDistinctId()),
+            URLQueryItem(name: "token", value: token),
+        ]
+        return components?.string
+    }
+
     func record(_ triggerTimestamp: Int64? = nil) {
         if shouldRecordSession && isScreenDirty() {
             let timestamp = triggerTimestamp ?? TimestampUtils.timestamp()

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
@@ -78,6 +78,8 @@ struct PayloadObjectID {
 
 struct EndPoints {
     static let defaultRecord = "https://api-js.mixpanel.com/record"
+    /// Base URL for session replay redirect (works for all data residency regions).
+    static let sessionReplayRedirect = "https://mixpanel.com/projects/replay-redirect"
 }
 
 struct TimingAdjustment {

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/MPSessionReplayInstanceTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/MPSessionReplayInstanceTests.swift
@@ -226,4 +226,61 @@ class MPSessionReplayInstanceTests: BaseTests {
 
         XCTAssertEqual(instance.flushService.getDistinctId(), newDistinctId)
     }
+
+    // MARK: - getSessionReplayUrl Tests
+
+    func testGetSessionReplayUrl_ReturnsNilWhenNotRecording() {
+        XCTAssertFalse(instance.isRecording)
+        XCTAssertNil(instance.getSessionReplayUrl())
+    }
+
+    func testGetSessionReplayUrl_ReturnsCorrectURLWhenRecording() {
+        startRecording()
+        XCTAssertTrue(instance.isRecording)
+
+        let url = instance.getSessionReplayUrl()
+        XCTAssertNotNil(url)
+
+        let replayId = SessionManager.shared.replayId
+        let distinctId = instance.flushService.getDistinctId()
+        let token = instance.token
+
+        XCTAssertTrue(url!.contains("https://mixpanel.com/projects/replay-redirect"))
+        XCTAssertTrue(url!.contains("replay_id=\(replayId)"))
+        XCTAssertTrue(url!.contains("distinct_id=\(distinctId)"))
+        XCTAssertTrue(url!.contains("token=\(token)"))
+    }
+
+    func testGetSessionReplayUrl_ReturnsValidURLWithSpecialCharacters() {
+        // Create instance with special characters that require encoding
+        let specialDistinctId = "user+test&param=value"
+        let config = MPSessionReplayConfig(
+            wifiOnly: false, autoStartRecording: false, enableLogging: false)
+        let testInstance = MPSessionReplayInstance(
+            token: "test-token",
+            distinctId: specialDistinctId,
+            config: config
+        )
+
+        testInstance.startRecording(sessionsPercent: 100)
+        XCTAssertTrue(testInstance.isRecording)
+
+        let urlString = testInstance.getSessionReplayUrl()
+        XCTAssertNotNil(urlString)
+
+        // Verify it's a valid URL that can be parsed
+        let url = URL(string: urlString!)
+        XCTAssertNotNil(url, "getSessionReplayUrl must return a valid URL")
+
+        // Verify all query parameters can be correctly extracted
+        let components = URLComponents(string: urlString!)
+        XCTAssertNotNil(components)
+
+        let distinctIdItem = components?.queryItems?.first { $0.name == "distinct_id" }
+        XCTAssertEqual(
+            distinctIdItem?.value, specialDistinctId,
+            "distinctId should be properly encoded and decodable")
+
+        testInstance.stopRecording()
+    }
 }

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/MPSessionReplayInstanceTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/MPSessionReplayInstanceTests.swift
@@ -280,6 +280,9 @@ class MPSessionReplayInstanceTests: BaseTests {
         XCTAssertEqual(
             distinctIdItem?.value, specialDistinctId,
             "distinctId should be properly encoded and decodable")
+        let encodedQuery = components?.percentEncodedQuery
+        XCTAssertTrue(encodedQuery?.contains("distinct_id=user%2Btest%26param%3Dvalue") == true)
+        XCTAssertFalse(encodedQuery?.contains("distinct_id=user+test") == true)
 
         testInstance.stopRecording()
     }

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/MPSessionReplayInstanceTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/MPSessionReplayInstanceTests.swift
@@ -227,18 +227,18 @@ class MPSessionReplayInstanceTests: BaseTests {
         XCTAssertEqual(instance.flushService.getDistinctId(), newDistinctId)
     }
 
-    // MARK: - getSessionReplayUrl Tests
+    // MARK: - getSessionReplayURL Tests
 
     func testGetSessionReplayUrl_ReturnsNilWhenNotRecording() {
         XCTAssertFalse(instance.isRecording)
-        XCTAssertNil(instance.getSessionReplayUrl())
+        XCTAssertNil(instance.getSessionReplayURL())
     }
 
     func testGetSessionReplayUrl_ReturnsCorrectURLWhenRecording() {
         startRecording()
         XCTAssertTrue(instance.isRecording)
 
-        let url = instance.getSessionReplayUrl()
+        let url = instance.getSessionReplayURL()
         XCTAssertNotNil(url)
 
         let replayId = SessionManager.shared.replayId
@@ -265,12 +265,12 @@ class MPSessionReplayInstanceTests: BaseTests {
         testInstance.startRecording(sessionsPercent: 100)
         XCTAssertTrue(testInstance.isRecording)
 
-        let urlString = testInstance.getSessionReplayUrl()
+        let urlString = testInstance.getSessionReplayURL()
         XCTAssertNotNil(urlString)
 
         // Verify it's a valid URL that can be parsed
         let url = URL(string: urlString!)
-        XCTAssertNotNil(url, "getSessionReplayUrl must return a valid URL")
+        XCTAssertNotNil(url, "getSessionReplayURL must return a valid URL")
 
         // Verify all query parameters can be correctly extracted
         let components = URLComponents(string: urlString!)


### PR DESCRIPTION
## Summary
- Adds `getSessionReplayUrl()` method to `MPSessionReplayInstance` that returns a URL to view the current session replay in the Mixpanel dashboard
- Returns `nil` when not recording
- URL format: `https://mixpanel.com/projects/replay-redirect?replay_id=<id>&distinct_id=<id>&token=<token>`

## Test plan
- [x] Unit tests added for returning nil when not recording
- [x] Unit tests added for correct URL format when recording
- [x] Unit tests added for URL validity with special characters in distinctId
- [x] Build passes

Linear: SDK-23