### PR TITLE
feat: support for data residency

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -57,3 +57,36 @@ if [ -n "$UNFORMATTED_CMD" ]; then
 fi
 
 echo "✅ All staged Swift files are formatted correctly"
+
+# Check for trailing commas before closing paren (not caught by swift-format)
+echo ""
+echo "→ Checking for trailing commas in function calls"
+
+TRAILING_COMMA_FILES=""
+
+for file in $STAGED_FILES; do
+  STAGED_TMP=$(mktemp)
+  if git show ":$file" > "$STAGED_TMP" 2>/dev/null; then
+    MATCHES=$(awk '
+      /,[ \t]*$/ { found=1; lineno=NR; line=$0; next }
+      found && /^[ \t]*[)\>]/ { print lineno ": " line; found=0; next }
+      { found=0 }
+    ' "$STAGED_TMP")
+    if [ -n "$MATCHES" ]; then
+      echo ""
+      echo "  $file"
+      echo "$MATCHES" | sed 's/^/    /'
+      TRAILING_COMMA_FILES="$TRAILING_COMMA_FILES $file"
+    fi
+    rm -f "$STAGED_TMP"
+  fi
+done
+
+if [ -n "$TRAILING_COMMA_FILES" ]; then
+  echo ""
+  echo "❌ Found trailing commas in function calls (invalid in Swift < 6.1)"
+  echo "   Remove the trailing comma from the last argument."
+  exit 1
+fi
+
+echo "✅ No trailing commas found in function calls"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -130,3 +130,46 @@ jobs:
           fi
 
           echo "✅ All changed Swift files are formatted correctly"
+
+      - name: Check for trailing commas in function calls
+        if: always()
+        continue-on-error: true  # Non-blocking: informational only
+        run: |
+          echo "→ Checking for trailing commas in function calls (invalid in Swift < 6.1)"
+          echo ""
+
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT origin/${{ github.base_ref }}...HEAD | grep '\.swift$' || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "ℹ️  No Swift files changed in this PR"
+            exit 0
+          fi
+
+          TRAILING_COMMA_FILES=""
+
+          for file in $CHANGED_FILES; do
+            if [ -f "$file" ]; then
+              MATCHES=$(awk '
+                /,[ \t]*$/ { found=1; lineno=NR; line=$0; next }
+                found && /^[ \t]*[)\>]/ { print lineno ": " line; found=0; next }
+                { found=0 }
+              ' "$file")
+              if [ -n "$MATCHES" ]; then
+                echo "  $file"
+                echo "$MATCHES" | sed 's/^/    /'
+                echo ""
+                TRAILING_COMMA_FILES="$TRAILING_COMMA_FILES $file"
+              fi
+            fi
+          done
+
+          if [ -n "$TRAILING_COMMA_FILES" ]; then
+            echo "❌ Found trailing commas in function calls (invalid in Swift < 6.1)"
+            echo "   Remove the trailing comma from the last argument."
+            echo ""
+            echo "ℹ️  This check is informational only and won't block your PR."
+            echo "   However, these should be fixed before merging."
+            exit 1
+          fi
+
+          echo "✅ No trailing commas found in function calls"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -133,7 +133,6 @@ jobs:
 
       - name: Check for trailing commas in function calls
         if: always()
-        continue-on-error: true  # Non-blocking: informational only
         run: |
           echo "→ Checking for trailing commas in function calls (invalid in Swift < 6.1)"
           echo ""

--- a/.swift-format
+++ b/.swift-format
@@ -6,5 +6,6 @@
   },
   "tabWidth": 4,
   "indentConditionalCompilationBlocks": false,
-  "indentSwitchCaseLabels": true
+  "indentSwitchCaseLabels": true,
+  "trailingCommas": "neverUsed"
 }

--- a/MixpanelSessionReplay/MixpanelSessionReplay.xcodeproj/project.pbxproj
+++ b/MixpanelSessionReplay/MixpanelSessionReplay.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		169611DA2EF547EB00923CFE /* SessionReplayCompatibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169611D92EF547EA00923CFE /* SessionReplayCompatibilityChecker.swift */; };
 		16991D0A2DDE580100E43ED4 /* ThreadUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16991D092DDE57FC00E43ED4 /* ThreadUtils.swift */; };
 		16C9EFC32D4AAD840005ED7E /* MPSessionReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C9EFC22D4AAD840005ED7E /* MPSessionReplay.swift */; };
+		16D9D0D72FD7D4FD005A6762 /* MPSessionReplayAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D9D0D62FD7D4FD005A6762 /* MPSessionReplayAPITests.swift */; };
 		1707D96A2DEE424F00D330D6 /* SwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1707D9692DEE424F00D330D6 /* SwizzlerTests.swift */; };
 		1723182C2C35ED9700EF3FEF /* Swizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1723182B2C35ED9700EF3FEF /* Swizzler.swift */; };
 		174B50A32CC8618E00861A62 /* ScreenRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174B50A22CC8618E00861A62 /* ScreenRecorder.swift */; };
@@ -116,6 +117,7 @@
 		169611D92EF547EA00923CFE /* SessionReplayCompatibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayCompatibilityChecker.swift; sourceTree = "<group>"; };
 		16991D092DDE57FC00E43ED4 /* ThreadUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadUtils.swift; sourceTree = "<group>"; };
 		16C9EFC22D4AAD840005ED7E /* MPSessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPSessionReplay.swift; sourceTree = "<group>"; };
+		16D9D0D62FD7D4FD005A6762 /* MPSessionReplayAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPSessionReplayAPITests.swift; sourceTree = "<group>"; };
 		1707D9692DEE424F00D330D6 /* SwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwizzlerTests.swift; sourceTree = "<group>"; };
 		1723182B2C35ED9700EF3FEF /* Swizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Swizzler.swift; sourceTree = "<group>"; };
 		174B50A22CC8618E00861A62 /* ScreenRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenRecorder.swift; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 		167A788A2D6F729F00298D2C /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				16D9D0D62FD7D4FD005A6762 /* MPSessionReplayAPITests.swift */,
 				16851AD52EF5C7AE004E574B /* SessionReplayCompatibilityCheckerTests.swift */,
 				167A789A2D762C8C00298D2C /* ViewUtilsTests.swift */,
 				1707D9692DEE424F00D330D6 /* SwizzlerTests.swift */,
@@ -597,6 +600,7 @@
 				167A78962D7626F000298D2C /* BaseTests.swift in Sources */,
 				164C4AAD2F33144100230843 /* MPSessionReplayTests.swift in Sources */,
 				864D00022C450954003B258E /* FlushServiceTests.swift in Sources */,
+				16D9D0D72FD7D4FD005A6762 /* MPSessionReplayAPITests.swift in Sources */,
 				16851AD62EF5C7AF004E574B /* SessionReplayCompatibilityCheckerTests.swift in Sources */,
 				1659D0472F7A64B0009208CE /* MaskDecisionTests.swift in Sources */,
 				1659D0482F7A64B0009208CE /* DebugOptionsTests.swift in Sources */,

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
@@ -9,6 +9,7 @@ import UIKit
 public enum MPSessionReplayError: Error {
     case failedToInitialize
     case disabledByRemoteSetting(message: String)
+    case invalidConfigServerUrl(message: String)
     case custom(message: String)
 }
 
@@ -126,9 +127,21 @@ final class MPSessionReplayManager {
         token: String, distinctId: String, config: MPSessionReplayConfig,
         completion: @escaping (Result<MPSessionReplayInstance?, Error>) -> Void
     ) {
-        deinitializeInstance()
-
         updateLoggingEnabled(config.enableLogging)
+
+        if !config.validateServerUrl() {
+            PrintLogging.shared.log(
+                .error,
+                "SDK initialization failed: \(config.serverUrl) is not a valid server URL. Provide valid server URL and try initializing again."
+            )
+            completion(
+                .failure(
+                    MPSessionReplayError.invalidConfigServerUrl(
+                        message: "SDK initialization failed: \(config.serverUrl) is not a valid server URL")))
+            return
+        }
+
+        deinitializeInstance()
 
         // Check settings before creating instance
         let settingsService =

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
@@ -129,15 +129,15 @@ final class MPSessionReplayManager {
     ) {
         updateLoggingEnabled(config.enableLogging)
 
-        if !config.validateServerUrl() {
+        if !config.validateServerURL() {
             PrintLogging.shared.log(
                 .error,
-                "SDK initialization failed: \(config.serverUrl) is not a valid server URL. Provide valid server URL and try initializing again."
+                "SDK initialization failed: \(config.serverURL) is not a valid server URL. Provide valid server URL and try initializing again."
             )
             completion(
                 .failure(
                     MPSessionReplayError.invalidConfigServerUrl(
-                        message: "SDK initialization failed: \(config.serverUrl) is not a valid server URL")))
+                        message: "SDK initialization failed: \(config.serverURL) is not a valid server URL")))
             return
         }
 
@@ -147,7 +147,7 @@ final class MPSessionReplayManager {
         let settingsService =
             testOverride_settingsService
             ?? SettingsService(
-                serverURL: config.serverUrl,
+                serverURL: config.serverURL,
                 version: APIConstants.currentLibVersion,
                 mpLib: APIConstants.currentMpLib,
             )

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
@@ -9,7 +9,6 @@ import UIKit
 public enum MPSessionReplayError: Error {
     case failedToInitialize
     case disabledByRemoteSetting(message: String)
-    case invalidConfigServerUrl(message: String)
     case custom(message: String)
 }
 
@@ -136,7 +135,7 @@ final class MPSessionReplayManager {
             )
             completion(
                 .failure(
-                    MPSessionReplayError.invalidConfigServerUrl(
+                    MPSessionReplayError.custom(
                         message: "SDK initialization failed: \(config.serverURL) is not a valid server URL")))
             return
         }

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
@@ -147,8 +147,9 @@ final class MPSessionReplayManager {
         let settingsService =
             testOverride_settingsService
             ?? SettingsService(
+                serverURL: config.serverUrl,
                 version: APIConstants.currentLibVersion,
-                mpLib: APIConstants.currentMpLib
+                mpLib: APIConstants.currentMpLib,
             )
         settingsService.getRemoteConfiguration(
             token: token,

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
@@ -147,9 +147,9 @@ final class MPSessionReplayManager {
         let settingsService =
             testOverride_settingsService
             ?? SettingsService(
-                serverURL: config.serverURL,
                 version: APIConstants.currentLibVersion,
                 mpLib: APIConstants.currentMpLib,
+                serverURL: config.serverURL,
             )
         settingsService.getRemoteConfiguration(
             token: token,

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift
@@ -149,7 +149,7 @@ final class MPSessionReplayManager {
             ?? SettingsService(
                 version: APIConstants.currentLibVersion,
                 mpLib: APIConstants.currentMpLib,
-                serverURL: config.serverURL,
+                serverURL: config.serverURL
             )
         settingsService.getRemoteConfiguration(
             token: token,

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
@@ -43,6 +43,7 @@ open class MPSessionReplayInstance: MPSessionReplaying {
         eventService = EventService()
         flushService = FlushService(
             token: token, distinctId: distinctId, eventService: eventService, wifiOnly: config.wifiOnly,
+            serverUrl: config.serverUrl,
             flushInterval: config.flushInterval)
 
         // Initialize debug mask overlay if enabled (DEBUG builds only)
@@ -288,7 +289,7 @@ open class MPSessionReplayInstance: MPSessionReplaying {
     /// - Returns: The session replay URL if recording is active, or `nil` if not recording.
     public func getSessionReplayURL() -> String? {
         guard isRecording else { return nil }
-        var components = URLComponents(string: EndPoints.sessionReplayRedirect)
+        var components = URLComponents(string: MPSessionReplayAPI.sessionReplayRedirect)
         components?.queryItems = [
             URLQueryItem(name: "replay_id", value: SessionManager.shared.replayId),
             URLQueryItem(name: "distinct_id", value: flushService.getDistinctId()),

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
@@ -43,8 +43,7 @@ open class MPSessionReplayInstance: MPSessionReplaying {
         eventService = EventService()
         flushService = FlushService(
             token: token, distinctId: distinctId, eventService: eventService, wifiOnly: config.wifiOnly,
-            serverURL: config.serverURL,
-            flushInterval: config.flushInterval)
+            flushInterval: config.flushInterval, serverURL: config.serverURL)
 
         // Initialize debug mask overlay if enabled (DEBUG builds only)
         if let overlayColors = config.debugOptions?.overlayColors,

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
@@ -43,7 +43,7 @@ open class MPSessionReplayInstance: MPSessionReplaying {
         eventService = EventService()
         flushService = FlushService(
             token: token, distinctId: distinctId, eventService: eventService, wifiOnly: config.wifiOnly,
-            serverUrl: config.serverUrl,
+            serverURL: config.serverURL,
             flushInterval: config.flushInterval)
 
         // Initialize debug mask overlay if enabled (DEBUG builds only)

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
@@ -127,15 +127,15 @@ public struct MPSessionReplayConfig: Codable {
     ///
     /// Example:
     /// ```swift
-    /// let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.euDataResidency)
+    /// let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.euDataResidency)
     /// ```
     ///
     /// - Note: The URL is trimmed and validated when SDK is getting initialized. If url validation fails, SDK will not be initialized.
     ///
     /// - Default: `MPSessionReplayAPI.usDataResidency` (US data residency)
-    public var serverUrl: String = MPSessionReplayAPI.usDataResidency {
+    public var serverURL: String = MPSessionReplayAPI.usDataResidency {
         didSet {
-            serverUrl = getTrimmedServerUrl(urlString: serverUrl)
+            serverURL = getTrimmedServerURL(urlString: serverURL)
         }
     }
 
@@ -197,7 +197,7 @@ public struct MPSessionReplayConfig: Codable {
     ///   - autoStartRecording: **Deprecated**, use `recordingSessionsPercent` instead. This property will be removed in a future release.
     ///   - recordingSessionsPercent: The sampling rate for automatically started recording session replays.
     ///   - remoteSettingsMode: Controls how remote configuration settings are fetched.
-    ///   - serverUrl: The data residency base URL. Use `MPSessionReplayAPI.usDataResidency` (default), `MPSessionReplayAPI.euDataResidency`, `MPSessionReplayAPI.inDataResidency`, or a custom URL.
+    ///   - serverURL: The data residency base URL. Use `MPSessionReplayAPI.usDataResidency` (default), `MPSessionReplayAPI.euDataResidency`, `MPSessionReplayAPI.inDataResidency`, or a custom URL.
     ///   - enableLogging: Enables debug-level logging for the SDK.
     ///   - flushInterval: Specifies the flush interval in seconds.
     ///   - enableSessionReplayOniOS26AndLater: Forces Session Replay to be enabled on iOS 26 and later.
@@ -208,7 +208,7 @@ public struct MPSessionReplayConfig: Codable {
         autoStartRecording: Bool = true,
         recordingSessionsPercent: Double = 100,
         remoteSettingsMode: RemoteSettingsMode = .disabled,
-        serverUrl: String = MPSessionReplayAPI.usDataResidency,
+        serverURL: String = MPSessionReplayAPI.usDataResidency,
         enableLogging: Bool = false,
         flushInterval: TimeInterval = 10,
         enableSessionReplayOniOS26AndLater: Bool = false,
@@ -219,20 +219,20 @@ public struct MPSessionReplayConfig: Codable {
         self.autoStartRecording = autoStartRecording
         self.recordingSessionsPercent = recordingSessionsPercent
         self.remoteSettingsMode = remoteSettingsMode
-        self.serverUrl = getTrimmedServerUrl(urlString: serverUrl)
+        self.serverURL = getTrimmedServerURL(urlString: serverURL)
         self.enableLogging = enableLogging
         self.flushInterval = flushInterval
         self.enableSessionReplayOniOS26AndLater = enableSessionReplayOniOS26AndLater
         self.debugOptions = debugOptions
     }
 
-    /// Validates the serverUrl and logs errors if invalid
-    public func validateServerUrl() -> Bool {
+    /// Validates the serverURL and logs errors if invalid
+    public func validateServerURL() -> Bool {
         // Check if URL can be constructed
-        guard let url = URL(string: serverUrl) else {
+        guard let url = URL(string: serverURL) else {
             PrintLogging.shared.log(
                 .error,
-                "Invalid serverUrl provided: '\(serverUrl)'. This is not a valid URL format. Session replay data will fail to send. Please provide a valid HTTPS URL."
+                "Invalid serverURL provided: '\(serverURL)'. This is not a valid URL format. Session replay data will fail to send. Please provide a valid HTTPS URL."
             )
             return false
         }
@@ -242,7 +242,7 @@ public struct MPSessionReplayConfig: Codable {
             let scheme = url.scheme ?? "unknown"
             PrintLogging.shared.log(
                 .error,
-                "Insecure serverUrl provided: '\(serverUrl)'. The URL uses '\(scheme)' instead of 'https'. Session replay data transmission requires HTTPS for security. Please use a valid HTTPS URL."
+                "Insecure serverURL provided: '\(serverURL)'. The URL uses '\(scheme)' instead of 'https'. Session replay data transmission requires HTTPS for security. Please use a valid HTTPS URL."
             )
             return false
         }
@@ -251,7 +251,7 @@ public struct MPSessionReplayConfig: Codable {
         guard let host = url.host, !host.isEmpty else {
             PrintLogging.shared.log(
                 .error,
-                "Invalid serverUrl provided: '\(serverUrl)'. The URL has no valid host. Session replay data will fail to send. Please provide a complete URL with a valid host."
+                "Invalid serverURL provided: '\(serverURL)'. The URL has no valid host. Session replay data will fail to send. Please provide a complete URL with a valid host."
             )
             return false
         }
@@ -260,7 +260,7 @@ public struct MPSessionReplayConfig: Codable {
         if !url.path.isEmpty && url.path != "/" {
             PrintLogging.shared.log(
                 .error,
-                "Invalid serverUrl provided: '\(serverUrl)'. The URL should not contain a path. Please provide only the base URL (e.g., 'https://api.mixpanel.com' not 'https://api.mixpanel.com/path"
+                "Invalid serverURL provided: '\(serverURL)'. The URL should not contain a path. Please provide only the base URL (e.g., 'https://api.mixpanel.com' not 'https://api.mixpanel.com/path"
             )
             return false
         }
@@ -268,7 +268,7 @@ public struct MPSessionReplayConfig: Codable {
         return true
     }
 
-    private func getTrimmedServerUrl(urlString: String) -> String {
+    private func getTrimmedServerURL(urlString: String) -> String {
         return urlString.trimmingCharacters(in: CharacterSet.whitespaces.union(CharacterSet(charactersIn: "/")))
     }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
@@ -194,7 +194,7 @@ public struct MPSessionReplayConfig: Codable {
     ///   - autoMaskedViews: Defines the views (from the `MPAutoMaskedViews` enum) that should be automatically masked in the replay.
     ///   This parameter is optional, with a default value of `[.image, .text, .web, .map]`.
     ///   To disable masking completely, explicitly pass an empty set `[]`.
-    ///   - autoStartRecording: **Deprec ated**, use `recordingSessionsPercent` instead. This property will be removed in a future release.
+    ///   - autoStartRecording: **Deprecated**, use `recordingSessionsPercent` instead. This property will be removed in a future release.
     ///   - recordingSessionsPercent: The sampling rate for automatically started recording session replays.
     ///   - remoteSettingsMode: Controls how remote configuration settings are fetched.
     ///   - enableLogging: Enables debug-level logging for the SDK.

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
@@ -101,22 +101,6 @@ public struct MPSessionReplayConfig: Codable {
     /// This default behavior can be overridden through the configuration.
     public var autoMaskedViews: Set<MPAutoMaskedViews> = [.image, .text, .web, .map]
 
-    /// Specifies the flush interval in seconds. The default is 10 seconds.
-    /// Screenshots are collected and sent to Mixpanel in batches of 10.
-    /// One batch is sent after each flush interval.
-    /// You can adjust the flush interval to delay or expedite the sending of screenshots.
-    public var flushInterval: TimeInterval = ReplaySettings.flushInterval
-
-    /// Enables debug-level logging for the SDK.
-    ///
-    /// - When set to `true`, the SDK will print verbose debug logs to the console to assist with development and troubleshooting.
-    ///   These logs may include internal events, configuration status, and lifecycle hooks relevant to session replay.
-    ///
-    /// - When set to `false`, logging is suppressed except for critical errors or warnings.
-    ///
-    /// - Default: `false`
-    public var enableLogging: Bool = false
-
     /// Specifies how the SDK should handle remote configuration fetched from Mixpanel servers.
     ///
     /// Remote settings allow you to dynamically control session replay behavior from the Mixpanel dashboard
@@ -133,6 +117,43 @@ public struct MPSessionReplayConfig: Codable {
     ///
     /// - SeeAlso: ``RemoteSettingsMode``
     public var remoteSettingsMode: RemoteSettingsMode = .disabled
+
+    /// Specifies the data residency base URL for sending session replay data.
+    ///
+    /// Use the predefined data residency constants:
+    /// - `MPSessionReplayAPI.usDataResidency` - US data residency (default): "https://api-js.mixpanel.com"
+    /// - `MPSessionReplayAPI.euDataResidency` - EU data residency: "https://api-eu.mixpanel.com"
+    /// - `MPSessionReplayAPI.inDataResidency` - India data residency: "https://api-in.mixpanel.com"
+    ///
+    /// Example:
+    /// ```swift
+    /// let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.euDataResidency)
+    /// ```
+    ///
+    /// - Note: The URL is trimmed and validated when SDK is getting initialized. If url validation fails, SDK will not be initialized.
+    ///
+    /// - Default: `MPSessionReplayAPI.usDataResidency` (US data residency)
+    public var serverUrl: String = MPSessionReplayAPI.usDataResidency {
+        didSet {
+            serverUrl = getTrimmedServerUrl(urlString: serverUrl)
+        }
+    }
+
+    /// Specifies the flush interval in seconds. The default is 10 seconds.
+    /// Screenshots are collected and sent to Mixpanel in batches of 10.
+    /// One batch is sent after each flush interval.
+    /// You can adjust the flush interval to delay or expedite the sending of screenshots.
+    public var flushInterval: TimeInterval = ReplaySettings.flushInterval
+
+    /// Enables debug-level logging for the SDK.
+    ///
+    /// - When set to `true`, the SDK will print verbose debug logs to the console to assist with development and troubleshooting.
+    ///   These logs may include internal events, configuration status, and lifecycle hooks relevant to session replay.
+    ///
+    /// - When set to `false`, logging is suppressed except for critical errors or warnings.
+    ///
+    /// - Default: `false`
+    public var enableLogging: Bool = false
 
     /// Forces Session Replay to be enabled on iOS 26 and later, bypassing compatibility checks.
     ///
@@ -176,6 +197,7 @@ public struct MPSessionReplayConfig: Codable {
     ///   - autoStartRecording: **Deprecated**, use `recordingSessionsPercent` instead. This property will be removed in a future release.
     ///   - recordingSessionsPercent: The sampling rate for automatically started recording session replays.
     ///   - remoteSettingsMode: Controls how remote configuration settings are fetched.
+    ///   - serverUrl: The data residency base URL. Use `MPSessionReplayAPI.usDataResidency` (default), `MPSessionReplayAPI.euDataResidency`, `MPSessionReplayAPI.inDataResidency`, or a custom URL.
     ///   - enableLogging: Enables debug-level logging for the SDK.
     ///   - flushInterval: Specifies the flush interval in seconds.
     ///   - enableSessionReplayOniOS26AndLater: Forces Session Replay to be enabled on iOS 26 and later.
@@ -186,6 +208,7 @@ public struct MPSessionReplayConfig: Codable {
         autoStartRecording: Bool = true,
         recordingSessionsPercent: Double = 100,
         remoteSettingsMode: RemoteSettingsMode = .disabled,
+        serverUrl: String = MPSessionReplayAPI.usDataResidency,
         enableLogging: Bool = false,
         flushInterval: TimeInterval = 10,
         enableSessionReplayOniOS26AndLater: Bool = false,
@@ -196,10 +219,57 @@ public struct MPSessionReplayConfig: Codable {
         self.autoStartRecording = autoStartRecording
         self.recordingSessionsPercent = recordingSessionsPercent
         self.remoteSettingsMode = remoteSettingsMode
+        self.serverUrl = getTrimmedServerUrl(urlString: serverUrl)
         self.enableLogging = enableLogging
         self.flushInterval = flushInterval
         self.enableSessionReplayOniOS26AndLater = enableSessionReplayOniOS26AndLater
         self.debugOptions = debugOptions
+    }
+
+    /// Validates the serverUrl and logs errors if invalid
+    public func validateServerUrl() -> Bool {
+        // Check if URL can be constructed
+        guard let url = URL(string: serverUrl) else {
+            PrintLogging.shared.log(
+                .error,
+                "Invalid serverUrl provided: '\(serverUrl)'. This is not a valid URL format. Session replay data will fail to send. Please provide a valid HTTPS URL."
+            )
+            return false
+        }
+
+        // Check if using HTTPS
+        guard url.scheme == "https" else {
+            let scheme = url.scheme ?? "unknown"
+            PrintLogging.shared.log(
+                .error,
+                "Insecure serverUrl provided: '\(serverUrl)'. The URL uses '\(scheme)' instead of 'https'. Session replay data transmission requires HTTPS for security. Please use a valid HTTPS URL."
+            )
+            return false
+        }
+
+        // Check if host exists and is not empty
+        guard let host = url.host, !host.isEmpty else {
+            PrintLogging.shared.log(
+                .error,
+                "Invalid serverUrl provided: '\(serverUrl)'. The URL has no valid host. Session replay data will fail to send. Please provide a complete URL with a valid host."
+            )
+            return false
+        }
+
+        // Check if URL contains a path (should be base URL only)
+        if !url.path.isEmpty && url.path != "/" {
+            PrintLogging.shared.log(
+                .error,
+                "Invalid serverUrl provided: '\(serverUrl)'. The URL should not contain a path. Please provide only the base URL (e.g., 'https://api.mixpanel.com' not 'https://api.mixpanel.com/path"
+            )
+            return false
+        }
+
+        return true
+    }
+
+    private func getTrimmedServerUrl(urlString: String) -> String {
+        return urlString.trimmingCharacters(in: CharacterSet.whitespaces.union(CharacterSet(charactersIn: "/")))
     }
 
     // Initialize from JSON

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
@@ -212,7 +212,7 @@ public struct MPSessionReplayConfig: Codable {
         flushInterval: TimeInterval = 10,
         enableSessionReplayOniOS26AndLater: Bool = false,
         debugOptions: DebugOptions? = nil,
-        serverURL: String = DataResidency.us,
+        serverURL: String = DataResidency.us
     ) {
         self.wifiOnly = wifiOnly
         self.autoMaskedViews = autoMaskedViews
@@ -252,15 +252,6 @@ public struct MPSessionReplayConfig: Codable {
             PrintLogging.shared.log(
                 .error,
                 "Invalid serverURL provided: '\(serverURL)'. The URL has no valid host. Session replay data will fail to send. Please provide a complete URL with a valid host."
-            )
-            return false
-        }
-
-        // Check if URL contains a path (should be base URL only)
-        if !url.path.isEmpty && url.path != "/" {
-            PrintLogging.shared.log(
-                .error,
-                "Invalid serverURL provided: '\(serverURL)'. The URL should not contain a path. Please provide only the base URL (e.g., 'https://api.mixpanel.com' not 'https://api.mixpanel.com/path"
             )
             return false
         }

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
@@ -118,27 +118,6 @@ public struct MPSessionReplayConfig: Codable {
     /// - SeeAlso: ``RemoteSettingsMode``
     public var remoteSettingsMode: RemoteSettingsMode = .disabled
 
-    /// Specifies the data residency base URL for sending session replay data.
-    ///
-    /// Use the predefined data residency constants:
-    /// - `MPSessionReplayAPI.usDataResidency` - US data residency (default): "https://api-js.mixpanel.com"
-    /// - `MPSessionReplayAPI.euDataResidency` - EU data residency: "https://api-eu.mixpanel.com"
-    /// - `MPSessionReplayAPI.inDataResidency` - India data residency: "https://api-in.mixpanel.com"
-    ///
-    /// Example:
-    /// ```swift
-    /// let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.euDataResidency)
-    /// ```
-    ///
-    /// - Note: The URL is trimmed and validated when SDK is getting initialized. If url validation fails, SDK will not be initialized.
-    ///
-    /// - Default: `MPSessionReplayAPI.usDataResidency` (US data residency)
-    public var serverURL: String = MPSessionReplayAPI.usDataResidency {
-        didSet {
-            serverURL = getTrimmedServerURL(urlString: serverURL)
-        }
-    }
-
     /// Specifies the flush interval in seconds. The default is 10 seconds.
     /// Screenshots are collected and sent to Mixpanel in batches of 10.
     /// One batch is sent after each flush interval.
@@ -187,6 +166,27 @@ public struct MPSessionReplayConfig: Codable {
     /// - SeeAlso: ``DebugOptions``, ``DebugOverlayColors``
     public var debugOptions: DebugOptions?
 
+    /// Specifies the data residency base URL for sending session replay data.
+    ///
+    /// Use the predefined data residency constants:
+    /// - `MPSessionReplayAPI.usDataResidency` - US data residency (default): "https://api-js.mixpanel.com"
+    /// - `MPSessionReplayAPI.euDataResidency` - EU data residency: "https://api-eu.mixpanel.com"
+    /// - `MPSessionReplayAPI.inDataResidency` - India data residency: "https://api-in.mixpanel.com"
+    ///
+    /// Example:
+    /// ```swift
+    /// let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.euDataResidency)
+    /// ```
+    ///
+    /// - Note: The URL is trimmed and validated when SDK is getting initialized. If url validation fails, SDK will not be initialized.
+    ///
+    /// - Default: `MPSessionReplayAPI.usDataResidency` (US data residency)
+    public var serverURL: String = MPSessionReplayAPI.usDataResidency {
+        didSet {
+            serverURL = getTrimmedServerURL(urlString: serverURL)
+        }
+    }
+
     /// Initializes a new `MPSessionReplayConfig` with the provided settings.
     ///
     /// - Parameters:
@@ -194,36 +194,36 @@ public struct MPSessionReplayConfig: Codable {
     ///   - autoMaskedViews: Defines the views (from the `MPAutoMaskedViews` enum) that should be automatically masked in the replay.
     ///   This parameter is optional, with a default value of `[.image, .text, .web, .map]`.
     ///   To disable masking completely, explicitly pass an empty set `[]`.
-    ///   - autoStartRecording: **Deprecated**, use `recordingSessionsPercent` instead. This property will be removed in a future release.
+    ///   - autoStartRecording: **Deprec ated**, use `recordingSessionsPercent` instead. This property will be removed in a future release.
     ///   - recordingSessionsPercent: The sampling rate for automatically started recording session replays.
     ///   - remoteSettingsMode: Controls how remote configuration settings are fetched.
-    ///   - serverURL: The data residency base URL. Use `MPSessionReplayAPI.usDataResidency` (default), `MPSessionReplayAPI.euDataResidency`, `MPSessionReplayAPI.inDataResidency`, or a custom URL.
     ///   - enableLogging: Enables debug-level logging for the SDK.
     ///   - flushInterval: Specifies the flush interval in seconds.
     ///   - enableSessionReplayOniOS26AndLater: Forces Session Replay to be enabled on iOS 26 and later.
     ///   - debugOptions: Debug feature configuration. When not nil, enables debug features (debug builds only).
+    ///   - serverURL: The data residency base URL. Use `MPSessionReplayAPI.usDataResidency` (default), `MPSessionReplayAPI.euDataResidency`, `MPSessionReplayAPI.inDataResidency`, or a custom URL.
     public init(
         wifiOnly: Bool = true,
         autoMaskedViews: Set<MPAutoMaskedViews> = [.image, .text, .web, .map],
         autoStartRecording: Bool = true,
         recordingSessionsPercent: Double = 100,
         remoteSettingsMode: RemoteSettingsMode = .disabled,
-        serverURL: String = MPSessionReplayAPI.usDataResidency,
         enableLogging: Bool = false,
         flushInterval: TimeInterval = 10,
         enableSessionReplayOniOS26AndLater: Bool = false,
-        debugOptions: DebugOptions? = nil
+        debugOptions: DebugOptions? = nil,
+        serverURL: String = MPSessionReplayAPI.usDataResidency,
     ) {
         self.wifiOnly = wifiOnly
         self.autoMaskedViews = autoMaskedViews
         self.autoStartRecording = autoStartRecording
         self.recordingSessionsPercent = recordingSessionsPercent
         self.remoteSettingsMode = remoteSettingsMode
-        self.serverURL = getTrimmedServerURL(urlString: serverURL)
         self.enableLogging = enableLogging
         self.flushInterval = flushInterval
         self.enableSessionReplayOniOS26AndLater = enableSessionReplayOniOS26AndLater
         self.debugOptions = debugOptions
+        self.serverURL = getTrimmedServerURL(urlString: serverURL)
     }
 
     /// Validates the serverURL and logs errors if invalid

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
@@ -169,19 +169,19 @@ public struct MPSessionReplayConfig: Codable {
     /// Specifies the data residency base URL for sending session replay data.
     ///
     /// Use the predefined data residency constants:
-    /// - `MPSessionReplayAPI.usDataResidency` - US data residency (default): "https://api-js.mixpanel.com"
-    /// - `MPSessionReplayAPI.euDataResidency` - EU data residency: "https://api-eu.mixpanel.com"
-    /// - `MPSessionReplayAPI.inDataResidency` - India data residency: "https://api-in.mixpanel.com"
+    /// - `DataResidency.us` - US data residency (default): "https://api.mixpanel.com"
+    /// - `DataResidency.eu` - EU data residency: "https://api-eu.mixpanel.com"
+    /// - `DataResidency.in` - India data residency: "https://api-in.mixpanel.com"
     ///
     /// Example:
     /// ```swift
-    /// let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.euDataResidency)
+    /// let config = MPSessionReplayConfig(serverURL: DataResidency.eu)
     /// ```
     ///
     /// - Note: The URL is trimmed and validated when SDK is getting initialized. If url validation fails, SDK will not be initialized.
     ///
-    /// - Default: `MPSessionReplayAPI.usDataResidency` (US data residency)
-    public var serverURL: String = MPSessionReplayAPI.usDataResidency {
+    /// - Default: `DataResidency.us` (US data residency)
+    public var serverURL: String = DataResidency.us {
         didSet {
             serverURL = getTrimmedServerURL(urlString: serverURL)
         }
@@ -201,7 +201,7 @@ public struct MPSessionReplayConfig: Codable {
     ///   - flushInterval: Specifies the flush interval in seconds.
     ///   - enableSessionReplayOniOS26AndLater: Forces Session Replay to be enabled on iOS 26 and later.
     ///   - debugOptions: Debug feature configuration. When not nil, enables debug features (debug builds only).
-    ///   - serverURL: The data residency base URL. Use `MPSessionReplayAPI.usDataResidency` (default), `MPSessionReplayAPI.euDataResidency`, `MPSessionReplayAPI.inDataResidency`, or a custom URL.
+    ///   - serverURL: The data residency base URL. Use `DataResidency.us` (default), `DataResidency.eu`, `DataResidency.in`, or a custom URL.
     public init(
         wifiOnly: Bool = true,
         autoMaskedViews: Set<MPAutoMaskedViews> = [.image, .text, .web, .map],
@@ -212,7 +212,7 @@ public struct MPSessionReplayConfig: Codable {
         flushInterval: TimeInterval = 10,
         enableSessionReplayOniOS26AndLater: Bool = false,
         debugOptions: DebugOptions? = nil,
-        serverURL: String = MPSessionReplayAPI.usDataResidency,
+        serverURL: String = DataResidency.us,
     ) {
         self.wifiOnly = wifiOnly
         self.autoMaskedViews = autoMaskedViews

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Network/FlushRequest.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Network/FlushRequest.swift
@@ -16,7 +16,7 @@ class FlushRequest {
 
     init(
         token: String, distinctId: String, network: Network = Network(),
-        serverURL: String = MPSessionReplayAPI.usDataResidency
+        serverURL: String = DataResidency.us
     ) {
         self.token = token
         self.distinctId = distinctId

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Network/FlushRequest.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Network/FlushRequest.swift
@@ -15,12 +15,12 @@ class FlushRequest {
     private let recordApiUrl: String
 
     init(
-        token: String, distinctId: String, serverUrl: String = MPSessionReplayAPI.usDataResidency,
+        token: String, distinctId: String, serverURL: String = MPSessionReplayAPI.usDataResidency,
         network: Network = Network()
     ) {
         self.token = token
         self.distinctId = distinctId
-        self.recordApiUrl = MPSessionReplayAPI.recordEndpoint(for: serverUrl)
+        self.recordApiUrl = MPSessionReplayAPI.recordEndpoint(for: serverURL)
 
         if let data = "\(token):".data(using: .utf8) {
             headers["Authorization"] = "Basic \(data.base64EncodedString())"

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Network/FlushRequest.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Network/FlushRequest.swift
@@ -15,8 +15,8 @@ class FlushRequest {
     private let recordApiUrl: String
 
     init(
-        token: String, distinctId: String, serverURL: String = MPSessionReplayAPI.usDataResidency,
-        network: Network = Network()
+        token: String, distinctId: String, network: Network = Network(),
+        serverURL: String = MPSessionReplayAPI.usDataResidency
     ) {
         self.token = token
         self.distinctId = distinctId

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Network/FlushRequest.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Network/FlushRequest.swift
@@ -12,10 +12,15 @@ class FlushRequest {
     let distinctId: String
     private var headers: [String: String] = [:]
     private let network: Network
+    private let recordApiUrl: String
 
-    init(token: String, distinctId: String, network: Network = Network()) {
+    init(
+        token: String, distinctId: String, serverUrl: String = MPSessionReplayAPI.usDataResidency,
+        network: Network = Network()
+    ) {
         self.token = token
         self.distinctId = distinctId
+        self.recordApiUrl = MPSessionReplayAPI.recordEndpoint(for: serverUrl)
 
         if let data = "\(token):".data(using: .utf8) {
             headers["Authorization"] = "Basic \(data.base64EncodedString())"
@@ -40,7 +45,7 @@ class FlushRequest {
             do {
                 let requestDataZip = try requestDataRaw.gzipCompressed()
                 let request = APIRequest(
-                    endPoint: EndPoints.defaultRecord, method: .post, requestBody: requestDataZip,
+                    endPoint: recordApiUrl, method: .post, requestBody: requestDataZip,
                     queryItems: buildQueryItems(payloadInfo: payloadInfo), headers: headers, timeoutInterval: nil)
 
                 let semaphore = DispatchSemaphore(value: 0)

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/FlushService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/FlushService.swift
@@ -11,7 +11,7 @@ class FlushService {
     public var wifiOnly: Bool
 
     private let token: String
-    private let serverUrl: String
+    private let serverURL: String
     var flushTimer: Timer?
     var flushSerialQueue: DispatchQueue
     private var eventService: EventService
@@ -21,15 +21,15 @@ class FlushService {
 
     init(
         token: String, distinctId: String, eventService: EventService, wifiOnly: Bool,
-        serverUrl: String = MPSessionReplayAPI.usDataResidency,
+        serverURL: String = MPSessionReplayAPI.usDataResidency,
         flushRequest: FlushRequest? = nil, networkMonitor: NetworkMonitoring = NetworkMonitor.shared,
         flushInterval: TimeInterval
     ) {
         self.token = token
-        self.serverUrl = serverUrl
+        self.serverURL = serverURL
         self.eventService = eventService
         self.wifiOnly = wifiOnly
-        self.flushRequest = flushRequest ?? FlushRequest(token: token, distinctId: distinctId, serverUrl: serverUrl)
+        self.flushRequest = flushRequest ?? FlushRequest(token: token, distinctId: distinctId, serverURL: serverURL)
         self.networkMonitor = networkMonitor
         self.flushInterval = flushInterval
         flushSerialQueue = DispatchQueue(
@@ -81,7 +81,7 @@ class FlushService {
     }
 
     func updateDistinctId(_ distinctId: String) {
-        self.flushRequest = FlushRequest(token: token, distinctId: distinctId, serverUrl: serverUrl)
+        self.flushRequest = FlushRequest(token: token, distinctId: distinctId, serverURL: serverURL)
         Logger.info(message: "Updated distinct id successfully.")
     }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/FlushService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/FlushService.swift
@@ -11,6 +11,7 @@ class FlushService {
     public var wifiOnly: Bool
 
     private let token: String
+    private let serverUrl: String
     var flushTimer: Timer?
     var flushSerialQueue: DispatchQueue
     private var eventService: EventService
@@ -20,13 +21,15 @@ class FlushService {
 
     init(
         token: String, distinctId: String, eventService: EventService, wifiOnly: Bool,
+        serverUrl: String = MPSessionReplayAPI.usDataResidency,
         flushRequest: FlushRequest? = nil, networkMonitor: NetworkMonitoring = NetworkMonitor.shared,
         flushInterval: TimeInterval
     ) {
         self.token = token
+        self.serverUrl = serverUrl
         self.eventService = eventService
         self.wifiOnly = wifiOnly
-        self.flushRequest = flushRequest ?? FlushRequest(token: token, distinctId: distinctId)
+        self.flushRequest = flushRequest ?? FlushRequest(token: token, distinctId: distinctId, serverUrl: serverUrl)
         self.networkMonitor = networkMonitor
         self.flushInterval = flushInterval
         flushSerialQueue = DispatchQueue(
@@ -78,7 +81,7 @@ class FlushService {
     }
 
     func updateDistinctId(_ distinctId: String) {
-        self.flushRequest = FlushRequest(token: token, distinctId: distinctId)
+        self.flushRequest = FlushRequest(token: token, distinctId: distinctId, serverUrl: serverUrl)
         Logger.info(message: "Updated distinct id successfully.")
     }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/FlushService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/FlushService.swift
@@ -21,9 +21,8 @@ class FlushService {
 
     init(
         token: String, distinctId: String, eventService: EventService, wifiOnly: Bool,
-        serverURL: String = MPSessionReplayAPI.usDataResidency,
         flushRequest: FlushRequest? = nil, networkMonitor: NetworkMonitoring = NetworkMonitor.shared,
-        flushInterval: TimeInterval
+        flushInterval: TimeInterval, serverURL: String = MPSessionReplayAPI.usDataResidency
     ) {
         self.token = token
         self.serverURL = serverURL

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/FlushService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/FlushService.swift
@@ -22,7 +22,7 @@ class FlushService {
     init(
         token: String, distinctId: String, eventService: EventService, wifiOnly: Bool,
         flushRequest: FlushRequest? = nil, networkMonitor: NetworkMonitoring = NetworkMonitor.shared,
-        flushInterval: TimeInterval, serverURL: String = MPSessionReplayAPI.usDataResidency
+        flushInterval: TimeInterval, serverURL: String = DataResidency.us
     ) {
         self.token = token
         self.serverURL = serverURL

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
@@ -20,17 +20,19 @@ class SettingsService {
     private let version: String
     private let mpLib: String
     private let userDefaults: UserDefaults
-
+    private let settingsEndPoint: String
     static let settingsTimeoutMS = 5.0
 
     init(
-        network: Network = Network(), version: String, mpLib: String,
+        network: Network = Network(), serverURL: String = MPSessionReplayAPI.usDataResidency, version: String,
+        mpLib: String,
         userDefaults: UserDefaults = UserDefaults(suiteName: ReplaySettings.userDefaultsName) ?? UserDefaults.standard
     ) {
         self.network = network
         self.version = version
         self.userDefaults = userDefaults
         self.mpLib = mpLib
+        settingsEndPoint = MPSessionReplayAPI.settingsEndpoint(for: serverURL)
     }
 
     func getRemoteConfiguration(
@@ -90,7 +92,7 @@ class SettingsService {
         }
 
         let apiRequest = APIRequest(
-            endPoint: MPSessionReplayAPI.settingsEndpoint,
+            endPoint: settingsEndPoint,
             method: .get,
             requestBody: nil,
             queryItems: queryItems,

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
@@ -27,7 +27,7 @@ class SettingsService {
         network: Network = Network(), version: String,
         mpLib: String,
         userDefaults: UserDefaults = UserDefaults(suiteName: ReplaySettings.userDefaultsName) ?? UserDefaults.standard,
-        serverURL: String = MPSessionReplayAPI.usDataResidency
+        serverURL: String = DataResidency.us
     ) {
         self.network = network
         self.version = version

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
@@ -24,9 +24,10 @@ class SettingsService {
     static let settingsTimeoutMS = 5.0
 
     init(
-        network: Network = Network(), serverURL: String = MPSessionReplayAPI.usDataResidency, version: String,
+        network: Network = Network(), version: String,
         mpLib: String,
-        userDefaults: UserDefaults = UserDefaults(suiteName: ReplaySettings.userDefaultsName) ?? UserDefaults.standard
+        userDefaults: UserDefaults = UserDefaults(suiteName: ReplaySettings.userDefaultsName) ?? UserDefaults.standard,
+        serverURL: String = MPSessionReplayAPI.usDataResidency
     ) {
         self.network = network
         self.version = version

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
@@ -22,7 +22,6 @@ class SettingsService {
     private let userDefaults: UserDefaults
 
     static let settingsTimeoutMS = 5.0
-    static let settingsEndpoint = "https://api.mixpanel.com/settings"
 
     init(
         network: Network = Network(), version: String, mpLib: String,
@@ -91,7 +90,7 @@ class SettingsService {
         }
 
         let apiRequest = APIRequest(
-            endPoint: Self.settingsEndpoint,
+            endPoint: MPSessionReplayAPI.settingsEndpoint,
             method: .get,
             requestBody: nil,
             queryItems: queryItems,

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
@@ -76,17 +76,24 @@ struct PayloadObjectID {
     static let mainSnapshot = 28
 }
 
-public struct MPSessionReplayAPI {
-    // Data Residency base URL (without paths)
-    /// US data residency (default)
-    public static let usDataResidency = "https://api-js.mixpanel.com"
-    /// EU data residency
-    public static let euDataResidency = "https://api-eu.mixpanel.com"
-    /// India data residency
-    public static let inDataResidency = "https://api-in.mixpanel.com"
+/// Data residency base URLs for Mixpanel Session Replay.
+///
+/// Use these constants to specify the data center region when configuring Session Replay.
+///
+/// Example:
+/// ```swift
+/// let config = MPSessionReplayConfig(serverURL: DataResidency.us)
+/// ```
+public struct DataResidency {
+    /// Base URL for US data residency (default).
+    public static let us = "https://api.mixpanel.com"
+    /// Base URL for EU data residency.
+    public static let eu = "https://api-eu.mixpanel.com"
+    /// Base URL for India data residency.
+    public static let `in` = "https://api-in.mixpanel.com"
+}
 
-    static let eventsEndpoint = "https://api.mixpanel.com"
-
+struct MPSessionReplayAPI {
     /// Base URL for session replay redirect (works for all data residency regions).
     static let sessionReplayRedirect = "https://mixpanel.com/projects/replay-redirect"
 
@@ -95,16 +102,16 @@ public struct MPSessionReplayAPI {
     private static let settingsPath = "/settings"
 
     /// Returns the full settings endpoint URL for the given data residency base URL
-    /// - Parameter serverURL: The data residency base URL (e.g., MPSessionReplayAPI.usDataResidency)
+    /// - Parameter serverURL: The data residency base URL (e.g., DataResidency.us)
     /// - Returns: Full settings endpoint URL (e.g., "https://api.mixpanel.com/settings")
-    static func settingsEndpoint(for serverURL: String = MPSessionReplayAPI.usDataResidency) -> String {
-        "\(eventsEndpoint)\(settingsPath)"
+    static func settingsEndpoint(for serverURL: String = DataResidency.us) -> String {
+        "\(DataResidency.us)\(settingsPath)"
     }
 
     /// Returns the full record endpoint URL for the given data residency base URL
-    /// - Parameter serverURL: The data residency base URL (e.g., MPSessionReplayAPI.usDataResidency)
+    /// - Parameter serverURL: The data residency base URL (e.g., DataResidency.us)
     /// - Returns: Full record endpoint URL (e.g., "https://api.mixpanel.com/record")
-    static func recordEndpoint(for serverURL: String = MPSessionReplayAPI.usDataResidency) -> String {
+    static func recordEndpoint(for serverURL: String = DataResidency.us) -> String {
         return "\(serverURL)\(recordPath)"
     }
 }

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
@@ -105,7 +105,7 @@ struct MPSessionReplayAPI {
     /// - Parameter serverURL: The data residency base URL (e.g., DataResidency.us)
     /// - Returns: Full settings endpoint URL (e.g., "https://api.mixpanel.com/settings")
     static func settingsEndpoint(for serverURL: String = DataResidency.us) -> String {
-        "\(DataResidency.us)\(settingsPath)"
+        "\(serverURL)\(settingsPath)"
     }
 
     /// Returns the full record endpoint URL for the given data residency base URL

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
@@ -95,17 +95,17 @@ public struct MPSessionReplayAPI {
     private static let settingsPath = "/settings"
 
     /// Returns the full settings endpoint URL for the given data residency base URL
-    /// - Parameter serverUrl: The data residency base URL (e.g., MPSessionReplayAPI.usDataResidency)
+    /// - Parameter serverURL: The data residency base URL (e.g., MPSessionReplayAPI.usDataResidency)
     /// - Returns: Full settings endpoint URL (e.g., "https://api.mixpanel.com/settings")
-    static func settingsEndpoint(for serverUrl: String = MPSessionReplayAPI.usDataResidency) -> String {
+    static func settingsEndpoint(for serverURL: String = MPSessionReplayAPI.usDataResidency) -> String {
         "\(eventsEndpoint)\(settingsPath)"
     }
 
     /// Returns the full record endpoint URL for the given data residency base URL
-    /// - Parameter serverUrl: The data residency base URL (e.g., MPSessionReplayAPI.usDataResidency)
+    /// - Parameter serverURL: The data residency base URL (e.g., MPSessionReplayAPI.usDataResidency)
     /// - Returns: Full record endpoint URL (e.g., "https://api.mixpanel.com/record")
-    static func recordEndpoint(for serverUrl: String = MPSessionReplayAPI.usDataResidency) -> String {
-        return "\(serverUrl)\(recordPath)"
+    static func recordEndpoint(for serverURL: String = MPSessionReplayAPI.usDataResidency) -> String {
+        return "\(serverURL)\(recordPath)"
     }
 }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
@@ -76,10 +76,33 @@ struct PayloadObjectID {
     static let mainSnapshot = 28
 }
 
-struct EndPoints {
-    static let defaultRecord = "https://api-js.mixpanel.com/record"
+public struct MPSessionReplayAPI {
+    // Data Residency base URL (without paths)
+    /// US data residency (default)
+    public static let usDataResidency = "https://api-js.mixpanel.com"
+    /// EU data residency
+    public static let euDataResidency = "https://api-eu.mixpanel.com"
+    /// India data residency
+    public static let inDataResidency = "https://api-in.mixpanel.com"
+
+    static let eventsEndpoint = "https://api.mixpanel.com"
+
     /// Base URL for session replay redirect (works for all data residency regions).
     static let sessionReplayRedirect = "https://mixpanel.com/projects/replay-redirect"
+
+    // Paths
+    private static let recordPath = "/record"
+    private static let settingsPath = "/settings"
+
+    // Settings endpoint (uses US data residency base url, constant across all data residencies)
+    static let settingsEndpoint = "\(eventsEndpoint)\(settingsPath)"
+
+    /// Returns the full record endpoint URL for the given data residency base URL
+    /// - Parameter serverUrl: The data residency base URL (e.g., MPSessionReplayAPI.usDataResidency)
+    /// - Returns: Full record endpoint URL (e.g., "https://api-js.mixpanel.com/record")
+    static func recordEndpoint(for serverUrl: String = MPSessionReplayAPI.usDataResidency) -> String {
+        return "\(serverUrl)\(recordPath)"
+    }
 }
 
 struct TimingAdjustment {

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
@@ -84,7 +84,7 @@ struct PayloadObjectID {
 /// ```swift
 /// let config = MPSessionReplayConfig(serverURL: DataResidency.us)
 /// ```
-public struct DataResidency {
+public enum DataResidency {
     /// Base URL for US data residency (default).
     public static let us = "https://api.mixpanel.com"
     /// Base URL for EU data residency.

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Utils/Constants.swift
@@ -94,12 +94,16 @@ public struct MPSessionReplayAPI {
     private static let recordPath = "/record"
     private static let settingsPath = "/settings"
 
-    // Settings endpoint (uses US data residency base url, constant across all data residencies)
-    static let settingsEndpoint = "\(eventsEndpoint)\(settingsPath)"
+    /// Returns the full settings endpoint URL for the given data residency base URL
+    /// - Parameter serverUrl: The data residency base URL (e.g., MPSessionReplayAPI.usDataResidency)
+    /// - Returns: Full settings endpoint URL (e.g., "https://api.mixpanel.com/settings")
+    static func settingsEndpoint(for serverUrl: String = MPSessionReplayAPI.usDataResidency) -> String {
+        "\(eventsEndpoint)\(settingsPath)"
+    }
 
     /// Returns the full record endpoint URL for the given data residency base URL
     /// - Parameter serverUrl: The data residency base URL (e.g., MPSessionReplayAPI.usDataResidency)
-    /// - Returns: Full record endpoint URL (e.g., "https://api-js.mixpanel.com/record")
+    /// - Returns: Full record endpoint URL (e.g., "https://api.mixpanel.com/record")
     static func recordEndpoint(for serverUrl: String = MPSessionReplayAPI.usDataResidency) -> String {
         return "\(serverUrl)\(recordPath)"
     }

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/MockClasses.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/MockClasses.swift
@@ -129,7 +129,7 @@ class MockNetwork: Network {
                 let response = HTTPURLResponse(
                     url: URL(string: "https://test.com")!,
                     statusCode: 200,
-                    httpVersion: nil, headerFields: [:],
+                    httpVersion: nil, headerFields: [:]
                 )
                 //return data from here so that the sendDecodableRequest can decode it without needing to set up a separate stub for sendDecodableRequest
                 completion(.success((data, response!)))

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/Models/MPSessionReplayConfigTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/Models/MPSessionReplayConfigTests.swift
@@ -63,7 +63,8 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "remoteSettingsMode": "disabled",
                 "enableLogging": true,
                 "flushInterval": 10.0,
-                "enableSessionReplayOniOS26AndLater": true
+                "enableSessionReplayOniOS26AndLater": true,
+                "serverUrl": "https://api-js.mixpanel.com"
             }
             """
         let jsonData = jsonString.data(using: .utf8)!
@@ -76,6 +77,7 @@ class MPSessionReplayConfigTests: XCTestCase {
         XCTAssertTrue(decodedConfig.enableLogging)
         XCTAssertEqual(decodedConfig.flushInterval, 10.0)
         XCTAssertEqual(decodedConfig.enableSessionReplayOniOS26AndLater, true)
+        XCTAssertEqual(decodedConfig.serverUrl, "https://api-js.mixpanel.com")
         XCTAssertNil(decodedConfig.debugOptions)
     }
 
@@ -106,6 +108,174 @@ class MPSessionReplayConfigTests: XCTestCase {
     func testEmptyAutoMaskedViews() {
         let config = MPSessionReplayConfig(autoMaskedViews: [])
         XCTAssertTrue(config.autoMaskedViews.isEmpty)
+    }
+
+    // MARK: - Data Center Configuration Tests
+
+    func testDefaultServerUrlIsUSDataResidency() {
+        let config = MPSessionReplayConfig()
+        XCTAssertEqual(
+            config.serverUrl,
+            MPSessionReplayAPI.usDataResidency,
+            "Default serverUrl should be US data residency"
+        )
+    }
+
+    func testCustomServerUrlUSDataResidency() {
+        let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.usDataResidency)
+        XCTAssertEqual(config.serverUrl, MPSessionReplayAPI.usDataResidency)
+    }
+
+    func testCustomServerUrlEUDataResidency() {
+        let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.euDataResidency)
+        XCTAssertEqual(
+            config.serverUrl,
+            MPSessionReplayAPI.euDataResidency,
+            "Should accept EU data residency URL"
+        )
+    }
+
+    func testCustomServerUrlIndiaDataResidency() {
+        let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.inDataResidency)
+        XCTAssertEqual(
+            config.serverUrl,
+            MPSessionReplayAPI.inDataResidency,
+            "Should accept India data residency URL"
+        )
+    }
+
+    func testCustomServerUrlWithCustomURL() {
+        let customURL = "https://custom.mixpanel.com"
+        let config = MPSessionReplayConfig(serverUrl: customURL)
+        XCTAssertEqual(
+            config.serverUrl,
+            customURL,
+            "Should accept custom data residency URL"
+        )
+    }
+
+    func testServerUrlEncodingDecoding() throws {
+        let originalConfig = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.euDataResidency)
+        let jsonData = try originalConfig.toJSON()
+        let decodedConfig = try MPSessionReplayConfig.from(json: jsonData)
+
+        XCTAssertEqual(
+            originalConfig.serverUrl,
+            decodedConfig.serverUrl,
+            "serverUrl should match after encoding and decoding"
+        )
+    }
+
+    func testServerUrlInJSONDecoding() throws {
+        let jsonString = """
+            {
+                "wifiOnly": true,
+                "recordingSessionsPercent": 100.0,
+                "autoMaskedViews": ["image", "text"],
+                "autoStartRecording": true,
+                "remoteSettingsMode": "disabled",
+                "enableLogging": false,
+                "flushInterval": 10.0,
+                "enableSessionReplayOniOS26AndLater": false,
+                "serverUrl": "https://api-eu.mixpanel.com"
+            }
+            """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedConfig = try MPSessionReplayConfig.from(json: jsonData)
+
+        XCTAssertEqual(
+            decodedConfig.serverUrl,
+            "https://api-eu.mixpanel.com",
+            "Should correctly decode serverUrl from JSON"
+        )
+    }
+
+    // MARK: - Server URL Validation Tests
+
+    func testValidateServerUrlWithUSDataResidency() {
+        let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.usDataResidency)
+        let isValid = config.validateServerUrl()
+        XCTAssertTrue(isValid, "US data residency URL should be valid")
+    }
+
+    func testValidateServerUrlWithEUDataResidency() {
+        let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.euDataResidency)
+        let isValid = config.validateServerUrl()
+        XCTAssertTrue(isValid, "EU data residency URL should be valid")
+    }
+
+    func testValidateServerUrlWithIndiaDataResidency() {
+        let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.inDataResidency)
+        let isValid = config.validateServerUrl()
+        XCTAssertTrue(isValid, "India data residency URL should be valid")
+    }
+
+    func testValidateServerUrlWithCustomValidUrl() {
+        let customURL = "https://custom.mixpanel.com"
+        let config = MPSessionReplayConfig(serverUrl: customURL)
+        let isValid = config.validateServerUrl()
+        XCTAssertTrue(isValid, "Custom HTTPS URL should be valid")
+    }
+
+    func testValidateServerUrlWithInvalidFormat() {
+        let invalidURL = "not-a-url-at-all"
+        let config = MPSessionReplayConfig(serverUrl: invalidURL)
+        let isValid = config.validateServerUrl()
+        XCTAssertFalse(isValid, "Malformed URL should be invalid")
+    }
+
+    func testValidateServerUrlWithHTTP() {
+        let insecureURL = "http://insecure.mixpanel.com"
+        let config = MPSessionReplayConfig(serverUrl: insecureURL)
+        let isValid = config.validateServerUrl()
+        XCTAssertFalse(isValid, "HTTP URL should be invalid (requires HTTPS)")
+    }
+
+    func testValidateServerUrlWithoutHost() {
+        let urlWithoutHost = "https://"
+        let config = MPSessionReplayConfig(serverUrl: urlWithoutHost)
+        let isValid = config.validateServerUrl()
+        XCTAssertFalse(isValid, "URL without host should be invalid")
+    }
+
+    func testValidateServerUrlWithEmptyString() {
+        let emptyURL = ""
+        let config = MPSessionReplayConfig(serverUrl: emptyURL)
+        let isValid = config.validateServerUrl()
+        XCTAssertFalse(isValid, "Empty URL should be invalid")
+    }
+
+    func testValidateServerUrlWithPath() {
+        let urlWithPath = "https://api.mixpanel.com/some/path"
+        let config = MPSessionReplayConfig(serverUrl: urlWithPath)
+        let isValid = config.validateServerUrl()
+        XCTAssertFalse(isValid, "HTTPS URL with path should be invalid")
+    }
+
+    func testValidateServerUrlWithFTPScheme() {
+        let ftpURL = "ftp://ftp.mixpanel.com"
+        let config = MPSessionReplayConfig(serverUrl: ftpURL)
+        let isValid = config.validateServerUrl()
+        XCTAssertFalse(isValid, "FTP URL should be invalid (requires HTTPS)")
+    }
+
+    func testValidateServerUrlWithOnlyPath() {
+        let onlyPath = "/just/a/path"
+        let config = MPSessionReplayConfig(serverUrl: onlyPath)
+        let isValid = config.validateServerUrl()
+        XCTAssertFalse(isValid, "Path-only string should be invalid")
+    }
+
+    func testConfigInitializationWithInvalidUrlStillStoresIt() {
+        // Even with invalid URL, config should initialize and store it
+        let invalidURL = "not-a-url"
+        let config = MPSessionReplayConfig(serverUrl: invalidURL)
+
+        XCTAssertEqual(
+            config.serverUrl,
+            invalidURL,
+            "Config should store invalid URL (validation logs error but doesn't prevent storage)"
+        )
     }
 
     // MARK: - RemoteSettingsMode Tests
@@ -154,6 +324,7 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "autoMaskedViews": ["text"],
                 "autoStartRecording": true,
                 "remoteSettingsMode": "disabled",
+                "serverUrl": "https://api-js.mixpanel.com",
                 "enableLogging": false,
                 "flushInterval": 10.0,
                 "enableSessionReplayOniOS26AndLater": false
@@ -170,6 +341,7 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "autoMaskedViews": ["text"],
                 "autoStartRecording": true,
                 "remoteSettingsMode": "strict",
+                "serverUrl": "https://api-js.mixpanel.com",
                 "enableLogging": false,
                 "flushInterval": 10.0,
                 "enableSessionReplayOniOS26AndLater": false
@@ -186,6 +358,7 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "autoMaskedViews": ["text"],
                 "autoStartRecording": true,
                 "remoteSettingsMode": "fallback",
+                "serverUrl": "https://api-js.mixpanel.com",
                 "enableLogging": false,
                 "flushInterval": 10.0,
                 "enableSessionReplayOniOS26AndLater": false

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/Models/MPSessionReplayConfigTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/Models/MPSessionReplayConfigTests.swift
@@ -249,7 +249,7 @@ class MPSessionReplayConfigTests: XCTestCase {
         let urlWithPath = "https://api.mixpanel.com/some/path"
         let config = MPSessionReplayConfig(serverURL: urlWithPath)
         let isValid = config.validateServerURL()
-        XCTAssertFalse(isValid, "HTTPS URL with path should be invalid")
+        XCTAssertTrue(isValid, "HTTPS URL with path should be valid")
     }
 
     func testValidateServerUrlWithFTPScheme() {

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/Models/MPSessionReplayConfigTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/Models/MPSessionReplayConfigTests.swift
@@ -64,7 +64,7 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "enableLogging": true,
                 "flushInterval": 10.0,
                 "enableSessionReplayOniOS26AndLater": true,
-                "serverUrl": "https://api-js.mixpanel.com"
+                "serverURL": "https://api-js.mixpanel.com"
             }
             """
         let jsonData = jsonString.data(using: .utf8)!
@@ -77,7 +77,7 @@ class MPSessionReplayConfigTests: XCTestCase {
         XCTAssertTrue(decodedConfig.enableLogging)
         XCTAssertEqual(decodedConfig.flushInterval, 10.0)
         XCTAssertEqual(decodedConfig.enableSessionReplayOniOS26AndLater, true)
-        XCTAssertEqual(decodedConfig.serverUrl, "https://api-js.mixpanel.com")
+        XCTAssertEqual(decodedConfig.serverURL, "https://api-js.mixpanel.com")
         XCTAssertNil(decodedConfig.debugOptions)
     }
 
@@ -115,30 +115,30 @@ class MPSessionReplayConfigTests: XCTestCase {
     func testDefaultServerUrlIsUSDataResidency() {
         let config = MPSessionReplayConfig()
         XCTAssertEqual(
-            config.serverUrl,
+            config.serverURL,
             MPSessionReplayAPI.usDataResidency,
-            "Default serverUrl should be US data residency"
+            "Default serverURL should be US data residency"
         )
     }
 
     func testCustomServerUrlUSDataResidency() {
-        let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.usDataResidency)
-        XCTAssertEqual(config.serverUrl, MPSessionReplayAPI.usDataResidency)
+        let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.usDataResidency)
+        XCTAssertEqual(config.serverURL, MPSessionReplayAPI.usDataResidency)
     }
 
     func testCustomServerUrlEUDataResidency() {
-        let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.euDataResidency)
+        let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.euDataResidency)
         XCTAssertEqual(
-            config.serverUrl,
+            config.serverURL,
             MPSessionReplayAPI.euDataResidency,
             "Should accept EU data residency URL"
         )
     }
 
     func testCustomServerUrlIndiaDataResidency() {
-        let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.inDataResidency)
+        let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.inDataResidency)
         XCTAssertEqual(
-            config.serverUrl,
+            config.serverURL,
             MPSessionReplayAPI.inDataResidency,
             "Should accept India data residency URL"
         )
@@ -146,23 +146,23 @@ class MPSessionReplayConfigTests: XCTestCase {
 
     func testCustomServerUrlWithCustomURL() {
         let customURL = "https://custom.mixpanel.com"
-        let config = MPSessionReplayConfig(serverUrl: customURL)
+        let config = MPSessionReplayConfig(serverURL: customURL)
         XCTAssertEqual(
-            config.serverUrl,
+            config.serverURL,
             customURL,
             "Should accept custom data residency URL"
         )
     }
 
     func testServerUrlEncodingDecoding() throws {
-        let originalConfig = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.euDataResidency)
+        let originalConfig = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.euDataResidency)
         let jsonData = try originalConfig.toJSON()
         let decodedConfig = try MPSessionReplayConfig.from(json: jsonData)
 
         XCTAssertEqual(
-            originalConfig.serverUrl,
-            decodedConfig.serverUrl,
-            "serverUrl should match after encoding and decoding"
+            originalConfig.serverURL,
+            decodedConfig.serverURL,
+            "serverURL should match after encoding and decoding"
         )
     }
 
@@ -177,102 +177,102 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "enableLogging": false,
                 "flushInterval": 10.0,
                 "enableSessionReplayOniOS26AndLater": false,
-                "serverUrl": "https://api-eu.mixpanel.com"
+                "serverURL": "https://api-eu.mixpanel.com"
             }
             """
         let jsonData = jsonString.data(using: .utf8)!
         let decodedConfig = try MPSessionReplayConfig.from(json: jsonData)
 
         XCTAssertEqual(
-            decodedConfig.serverUrl,
+            decodedConfig.serverURL,
             "https://api-eu.mixpanel.com",
-            "Should correctly decode serverUrl from JSON"
+            "Should correctly decode serverURL from JSON"
         )
     }
 
     // MARK: - Server URL Validation Tests
 
     func testValidateServerUrlWithUSDataResidency() {
-        let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.usDataResidency)
-        let isValid = config.validateServerUrl()
+        let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.usDataResidency)
+        let isValid = config.validateServerURL()
         XCTAssertTrue(isValid, "US data residency URL should be valid")
     }
 
     func testValidateServerUrlWithEUDataResidency() {
-        let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.euDataResidency)
-        let isValid = config.validateServerUrl()
+        let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.euDataResidency)
+        let isValid = config.validateServerURL()
         XCTAssertTrue(isValid, "EU data residency URL should be valid")
     }
 
     func testValidateServerUrlWithIndiaDataResidency() {
-        let config = MPSessionReplayConfig(serverUrl: MPSessionReplayAPI.inDataResidency)
-        let isValid = config.validateServerUrl()
+        let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.inDataResidency)
+        let isValid = config.validateServerURL()
         XCTAssertTrue(isValid, "India data residency URL should be valid")
     }
 
     func testValidateServerUrlWithCustomValidUrl() {
         let customURL = "https://custom.mixpanel.com"
-        let config = MPSessionReplayConfig(serverUrl: customURL)
-        let isValid = config.validateServerUrl()
+        let config = MPSessionReplayConfig(serverURL: customURL)
+        let isValid = config.validateServerURL()
         XCTAssertTrue(isValid, "Custom HTTPS URL should be valid")
     }
 
     func testValidateServerUrlWithInvalidFormat() {
         let invalidURL = "not-a-url-at-all"
-        let config = MPSessionReplayConfig(serverUrl: invalidURL)
-        let isValid = config.validateServerUrl()
+        let config = MPSessionReplayConfig(serverURL: invalidURL)
+        let isValid = config.validateServerURL()
         XCTAssertFalse(isValid, "Malformed URL should be invalid")
     }
 
     func testValidateServerUrlWithHTTP() {
         let insecureURL = "http://insecure.mixpanel.com"
-        let config = MPSessionReplayConfig(serverUrl: insecureURL)
-        let isValid = config.validateServerUrl()
+        let config = MPSessionReplayConfig(serverURL: insecureURL)
+        let isValid = config.validateServerURL()
         XCTAssertFalse(isValid, "HTTP URL should be invalid (requires HTTPS)")
     }
 
     func testValidateServerUrlWithoutHost() {
         let urlWithoutHost = "https://"
-        let config = MPSessionReplayConfig(serverUrl: urlWithoutHost)
-        let isValid = config.validateServerUrl()
+        let config = MPSessionReplayConfig(serverURL: urlWithoutHost)
+        let isValid = config.validateServerURL()
         XCTAssertFalse(isValid, "URL without host should be invalid")
     }
 
     func testValidateServerUrlWithEmptyString() {
         let emptyURL = ""
-        let config = MPSessionReplayConfig(serverUrl: emptyURL)
-        let isValid = config.validateServerUrl()
+        let config = MPSessionReplayConfig(serverURL: emptyURL)
+        let isValid = config.validateServerURL()
         XCTAssertFalse(isValid, "Empty URL should be invalid")
     }
 
     func testValidateServerUrlWithPath() {
         let urlWithPath = "https://api.mixpanel.com/some/path"
-        let config = MPSessionReplayConfig(serverUrl: urlWithPath)
-        let isValid = config.validateServerUrl()
+        let config = MPSessionReplayConfig(serverURL: urlWithPath)
+        let isValid = config.validateServerURL()
         XCTAssertFalse(isValid, "HTTPS URL with path should be invalid")
     }
 
     func testValidateServerUrlWithFTPScheme() {
         let ftpURL = "ftp://ftp.mixpanel.com"
-        let config = MPSessionReplayConfig(serverUrl: ftpURL)
-        let isValid = config.validateServerUrl()
+        let config = MPSessionReplayConfig(serverURL: ftpURL)
+        let isValid = config.validateServerURL()
         XCTAssertFalse(isValid, "FTP URL should be invalid (requires HTTPS)")
     }
 
     func testValidateServerUrlWithOnlyPath() {
         let onlyPath = "/just/a/path"
-        let config = MPSessionReplayConfig(serverUrl: onlyPath)
-        let isValid = config.validateServerUrl()
+        let config = MPSessionReplayConfig(serverURL: onlyPath)
+        let isValid = config.validateServerURL()
         XCTAssertFalse(isValid, "Path-only string should be invalid")
     }
 
     func testConfigInitializationWithInvalidUrlStillStoresIt() {
         // Even with invalid URL, config should initialize and store it
         let invalidURL = "not-a-url"
-        let config = MPSessionReplayConfig(serverUrl: invalidURL)
+        let config = MPSessionReplayConfig(serverURL: invalidURL)
 
         XCTAssertEqual(
-            config.serverUrl,
+            config.serverURL,
             invalidURL,
             "Config should store invalid URL (validation logs error but doesn't prevent storage)"
         )
@@ -324,7 +324,7 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "autoMaskedViews": ["text"],
                 "autoStartRecording": true,
                 "remoteSettingsMode": "disabled",
-                "serverUrl": "https://api-js.mixpanel.com",
+                "serverURL": "https://api-js.mixpanel.com",
                 "enableLogging": false,
                 "flushInterval": 10.0,
                 "enableSessionReplayOniOS26AndLater": false
@@ -341,7 +341,7 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "autoMaskedViews": ["text"],
                 "autoStartRecording": true,
                 "remoteSettingsMode": "strict",
-                "serverUrl": "https://api-js.mixpanel.com",
+                "serverURL": "https://api-js.mixpanel.com",
                 "enableLogging": false,
                 "flushInterval": 10.0,
                 "enableSessionReplayOniOS26AndLater": false
@@ -358,7 +358,7 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "autoMaskedViews": ["text"],
                 "autoStartRecording": true,
                 "remoteSettingsMode": "fallback",
-                "serverUrl": "https://api-js.mixpanel.com",
+                "serverURL": "https://api-js.mixpanel.com",
                 "enableLogging": false,
                 "flushInterval": 10.0,
                 "enableSessionReplayOniOS26AndLater": false

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/Models/MPSessionReplayConfigTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/Models/MPSessionReplayConfigTests.swift
@@ -64,7 +64,7 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "enableLogging": true,
                 "flushInterval": 10.0,
                 "enableSessionReplayOniOS26AndLater": true,
-                "serverURL": "https://api-js.mixpanel.com"
+                "serverURL": "https://api.mixpanel.com"
             }
             """
         let jsonData = jsonString.data(using: .utf8)!
@@ -77,7 +77,7 @@ class MPSessionReplayConfigTests: XCTestCase {
         XCTAssertTrue(decodedConfig.enableLogging)
         XCTAssertEqual(decodedConfig.flushInterval, 10.0)
         XCTAssertEqual(decodedConfig.enableSessionReplayOniOS26AndLater, true)
-        XCTAssertEqual(decodedConfig.serverURL, "https://api-js.mixpanel.com")
+        XCTAssertEqual(decodedConfig.serverURL, "https://api.mixpanel.com")
         XCTAssertNil(decodedConfig.debugOptions)
     }
 
@@ -116,30 +116,30 @@ class MPSessionReplayConfigTests: XCTestCase {
         let config = MPSessionReplayConfig()
         XCTAssertEqual(
             config.serverURL,
-            MPSessionReplayAPI.usDataResidency,
+            DataResidency.us,
             "Default serverURL should be US data residency"
         )
     }
 
     func testCustomServerUrlUSDataResidency() {
-        let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.usDataResidency)
-        XCTAssertEqual(config.serverURL, MPSessionReplayAPI.usDataResidency)
+        let config = MPSessionReplayConfig(serverURL: DataResidency.us)
+        XCTAssertEqual(config.serverURL, DataResidency.us)
     }
 
     func testCustomServerUrlEUDataResidency() {
-        let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.euDataResidency)
+        let config = MPSessionReplayConfig(serverURL: DataResidency.eu)
         XCTAssertEqual(
             config.serverURL,
-            MPSessionReplayAPI.euDataResidency,
+            DataResidency.eu,
             "Should accept EU data residency URL"
         )
     }
 
     func testCustomServerUrlIndiaDataResidency() {
-        let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.inDataResidency)
+        let config = MPSessionReplayConfig(serverURL: DataResidency.in)
         XCTAssertEqual(
             config.serverURL,
-            MPSessionReplayAPI.inDataResidency,
+            DataResidency.in,
             "Should accept India data residency URL"
         )
     }
@@ -155,7 +155,7 @@ class MPSessionReplayConfigTests: XCTestCase {
     }
 
     func testServerUrlEncodingDecoding() throws {
-        let originalConfig = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.euDataResidency)
+        let originalConfig = MPSessionReplayConfig(serverURL: DataResidency.eu)
         let jsonData = try originalConfig.toJSON()
         let decodedConfig = try MPSessionReplayConfig.from(json: jsonData)
 
@@ -193,19 +193,19 @@ class MPSessionReplayConfigTests: XCTestCase {
     // MARK: - Server URL Validation Tests
 
     func testValidateServerUrlWithUSDataResidency() {
-        let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.usDataResidency)
+        let config = MPSessionReplayConfig(serverURL: DataResidency.us)
         let isValid = config.validateServerURL()
         XCTAssertTrue(isValid, "US data residency URL should be valid")
     }
 
     func testValidateServerUrlWithEUDataResidency() {
-        let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.euDataResidency)
+        let config = MPSessionReplayConfig(serverURL: DataResidency.eu)
         let isValid = config.validateServerURL()
         XCTAssertTrue(isValid, "EU data residency URL should be valid")
     }
 
     func testValidateServerUrlWithIndiaDataResidency() {
-        let config = MPSessionReplayConfig(serverURL: MPSessionReplayAPI.inDataResidency)
+        let config = MPSessionReplayConfig(serverURL: DataResidency.in)
         let isValid = config.validateServerURL()
         XCTAssertTrue(isValid, "India data residency URL should be valid")
     }
@@ -324,7 +324,7 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "autoMaskedViews": ["text"],
                 "autoStartRecording": true,
                 "remoteSettingsMode": "disabled",
-                "serverURL": "https://api-js.mixpanel.com",
+                "serverURL": "https://api.mixpanel.com",
                 "enableLogging": false,
                 "flushInterval": 10.0,
                 "enableSessionReplayOniOS26AndLater": false
@@ -341,7 +341,7 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "autoMaskedViews": ["text"],
                 "autoStartRecording": true,
                 "remoteSettingsMode": "strict",
-                "serverURL": "https://api-js.mixpanel.com",
+                "serverURL": "https://api.mixpanel.com",
                 "enableLogging": false,
                 "flushInterval": 10.0,
                 "enableSessionReplayOniOS26AndLater": false
@@ -358,7 +358,7 @@ class MPSessionReplayConfigTests: XCTestCase {
                 "autoMaskedViews": ["text"],
                 "autoStartRecording": true,
                 "remoteSettingsMode": "fallback",
-                "serverURL": "https://api-js.mixpanel.com",
+                "serverURL": "https://api.mixpanel.com",
                 "enableLogging": false,
                 "flushInterval": 10.0,
                 "enableSessionReplayOniOS26AndLater": false

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/Network/NetworkTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/Network/NetworkTests.swift
@@ -30,7 +30,7 @@ class NetworkTests: XCTestCase {
     }
 
     func testPerformAPIRequestSuccess() {
-        let url = URL(string: EndPoints.defaultRecord)!
+        let url = URL(string: MPSessionReplayAPI.recordEndpoint())!
         let responseData = "Success".data(using: .utf8)
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
 
@@ -39,7 +39,7 @@ class NetworkTests: XCTestCase {
         }
 
         let apiRequest = APIRequest(
-            endPoint: EndPoints.defaultRecord,
+            endPoint: MPSessionReplayAPI.recordEndpoint(),
             method: .get,
             requestBody: nil,
             queryItems: nil,
@@ -70,7 +70,7 @@ class NetworkTests: XCTestCase {
         }
 
         let apiRequest = APIRequest(
-            endPoint: EndPoints.defaultRecord,
+            endPoint: MPSessionReplayAPI.recordEndpoint(),
             method: .get,
             requestBody: nil,
             queryItems: nil,
@@ -94,7 +94,7 @@ class NetworkTests: XCTestCase {
     }
 
     func testPerformAPIRequestInvalidResponse() {
-        let url = URL(string: EndPoints.defaultRecord)!
+        let url = URL(string: MPSessionReplayAPI.recordEndpoint())!
         let response = HTTPURLResponse(url: url, statusCode: 500, httpVersion: nil, headerFields: nil)!
 
         MockURLProtocol.requestHandler = { request in
@@ -102,7 +102,7 @@ class NetworkTests: XCTestCase {
         }
 
         let apiRequest = APIRequest(
-            endPoint: EndPoints.defaultRecord,
+            endPoint: MPSessionReplayAPI.recordEndpoint(),
             method: .get,
             requestBody: nil,
             queryItems: nil,

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/Utils/MPSessionReplayAPITests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/Utils/MPSessionReplayAPITests.swift
@@ -15,15 +15,15 @@ final class MPSessionReplayAPITests: XCTestCase {
 
     func testUSDataResidencyConstant() {
         XCTAssertEqual(
-            MPSessionReplayAPI.usDataResidency,
-            "https://api-js.mixpanel.com",
+            DataResidency.us,
+            "https://api.mixpanel.com",
             "US data residency URL should be correct"
         )
     }
 
     func testEUDataResidencyConstant() {
         XCTAssertEqual(
-            MPSessionReplayAPI.euDataResidency,
+            DataResidency.eu,
             "https://api-eu.mixpanel.com",
             "EU data residency URL should be correct"
         )
@@ -31,7 +31,7 @@ final class MPSessionReplayAPITests: XCTestCase {
 
     func testIndiaDataResidencyConstant() {
         XCTAssertEqual(
-            MPSessionReplayAPI.inDataResidency,
+            DataResidency.in,
             "https://api-in.mixpanel.com",
             "India data residency URL should be correct"
         )
@@ -40,16 +40,16 @@ final class MPSessionReplayAPITests: XCTestCase {
     // MARK: - Record Endpoint Tests
 
     func testRecordEndpointForUSDataResidency() {
-        let endpoint = MPSessionReplayAPI.recordEndpoint(for: MPSessionReplayAPI.usDataResidency)
+        let endpoint = MPSessionReplayAPI.recordEndpoint(for: DataResidency.us)
         XCTAssertEqual(
             endpoint,
-            "https://api-js.mixpanel.com/record",
+            "https://api.mixpanel.com/record",
             "US record endpoint should append /record path"
         )
     }
 
     func testRecordEndpointForEUDataResidency() {
-        let endpoint = MPSessionReplayAPI.recordEndpoint(for: MPSessionReplayAPI.euDataResidency)
+        let endpoint = MPSessionReplayAPI.recordEndpoint(for: DataResidency.eu)
         XCTAssertEqual(
             endpoint,
             "https://api-eu.mixpanel.com/record",
@@ -58,7 +58,7 @@ final class MPSessionReplayAPITests: XCTestCase {
     }
 
     func testRecordEndpointForIndiaDataResidency() {
-        let endpoint = MPSessionReplayAPI.recordEndpoint(for: MPSessionReplayAPI.inDataResidency)
+        let endpoint = MPSessionReplayAPI.recordEndpoint(for: DataResidency.in)
         XCTAssertEqual(
             endpoint,
             "https://api-in.mixpanel.com/record",
@@ -80,7 +80,7 @@ final class MPSessionReplayAPITests: XCTestCase {
         let endpoint = MPSessionReplayAPI.recordEndpoint()
         XCTAssertEqual(
             endpoint,
-            "https://api-js.mixpanel.com/record",
+            "https://api.mixpanel.com/record",
             "Record endpoint should default to US data residency"
         )
     }
@@ -89,7 +89,7 @@ final class MPSessionReplayAPITests: XCTestCase {
 
     func testSettingsEndpointIsConstant() {
         XCTAssertEqual(
-            MPSessionReplayAPI.settingsEndpoint,
+            MPSessionReplayAPI.settingsEndpoint(),
             "https://api.mixpanel.com/settings",
             "Settings endpoint should be constant across all data residencies"
         )
@@ -99,48 +99,48 @@ final class MPSessionReplayAPITests: XCTestCase {
 
     func testDataResidencyURLsDoNotContainPaths() {
         XCTAssertFalse(
-            MPSessionReplayAPI.usDataResidency.hasSuffix("/"),
+            DataResidency.us.hasSuffix("/"),
             "US data residency URL should not end with slash"
         )
         XCTAssertFalse(
-            MPSessionReplayAPI.usDataResidency.contains("/record"),
+            DataResidency.us.contains("/record"),
             "US data residency URL should not contain /record path"
         )
 
         XCTAssertFalse(
-            MPSessionReplayAPI.euDataResidency.hasSuffix("/"),
+            DataResidency.eu.hasSuffix("/"),
             "EU data residency URL should not end with slash"
         )
         XCTAssertFalse(
-            MPSessionReplayAPI.euDataResidency.contains("/record"),
+            DataResidency.eu.contains("/record"),
             "EU data residency URL should not contain /record path"
         )
 
         XCTAssertFalse(
-            MPSessionReplayAPI.inDataResidency.hasSuffix("/"),
+            DataResidency.in.hasSuffix("/"),
             "India data residency URL should not end with slash"
         )
         XCTAssertFalse(
-            MPSessionReplayAPI.inDataResidency.contains("/record"),
+            DataResidency.in.contains("/record"),
             "India data residency URL should not contain /record path"
         )
     }
 
     func testAllDataResidencyURLsAreHTTPS() {
         XCTAssertTrue(
-            MPSessionReplayAPI.usDataResidency.hasPrefix("https://"),
+            DataResidency.us.hasPrefix("https://"),
             "US data residency should use HTTPS"
         )
         XCTAssertTrue(
-            MPSessionReplayAPI.euDataResidency.hasPrefix("https://"),
+            DataResidency.eu.hasPrefix("https://"),
             "EU data residency should use HTTPS"
         )
         XCTAssertTrue(
-            MPSessionReplayAPI.inDataResidency.hasPrefix("https://"),
+            DataResidency.in.hasPrefix("https://"),
             "India data residency should use HTTPS"
         )
         XCTAssertTrue(
-            MPSessionReplayAPI.settingsEndpoint.hasPrefix("https://"),
+            MPSessionReplayAPI.settingsEndpoint().hasPrefix("https://"),
             "Settings endpoint should use HTTPS"
         )
     }

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/Utils/MPSessionReplayAPITests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/Utils/MPSessionReplayAPITests.swift
@@ -87,11 +87,21 @@ final class MPSessionReplayAPITests: XCTestCase {
 
     // MARK: - Settings Endpoint Tests
 
-    func testSettingsEndpointIsConstant() {
+    func testSettingsEndpoint() {
         XCTAssertEqual(
             MPSessionReplayAPI.settingsEndpoint(),
             "https://api.mixpanel.com/settings",
-            "Settings endpoint should be constant across all data residencies"
+            "Settings endpoint should return default when no data residency is specified"
+        )
+        XCTAssertEqual(
+            MPSessionReplayAPI.settingsEndpoint(for: DataResidency.in),
+            "https://api-in.mixpanel.com/settings",
+            "Settings endpoint should be of In data residency"
+        )
+        XCTAssertEqual(
+            MPSessionReplayAPI.settingsEndpoint(for: DataResidency.eu),
+            "https://api-eu.mixpanel.com/settings",
+            "Settings endpoint should be of EU data residency"
         )
     }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/Utils/MPSessionReplayAPITests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/Utils/MPSessionReplayAPITests.swift
@@ -1,0 +1,147 @@
+//
+//  MPSessionReplayAPITests.swift
+//  MixpanelSessionReplayTests
+//
+//  Copyright © 2025 Mixpanel. All rights reserved.
+//
+
+import XCTest
+
+@testable import MixpanelSessionReplay
+
+final class MPSessionReplayAPITests: XCTestCase {
+
+    // MARK: - Data Residency Constants Tests
+
+    func testUSDataResidencyConstant() {
+        XCTAssertEqual(
+            MPSessionReplayAPI.usDataResidency,
+            "https://api-js.mixpanel.com",
+            "US data residency URL should be correct"
+        )
+    }
+
+    func testEUDataResidencyConstant() {
+        XCTAssertEqual(
+            MPSessionReplayAPI.euDataResidency,
+            "https://api-eu.mixpanel.com",
+            "EU data residency URL should be correct"
+        )
+    }
+
+    func testIndiaDataResidencyConstant() {
+        XCTAssertEqual(
+            MPSessionReplayAPI.inDataResidency,
+            "https://api-in.mixpanel.com",
+            "India data residency URL should be correct"
+        )
+    }
+
+    // MARK: - Record Endpoint Tests
+
+    func testRecordEndpointForUSDataResidency() {
+        let endpoint = MPSessionReplayAPI.recordEndpoint(for: MPSessionReplayAPI.usDataResidency)
+        XCTAssertEqual(
+            endpoint,
+            "https://api-js.mixpanel.com/record",
+            "US record endpoint should append /record path"
+        )
+    }
+
+    func testRecordEndpointForEUDataResidency() {
+        let endpoint = MPSessionReplayAPI.recordEndpoint(for: MPSessionReplayAPI.euDataResidency)
+        XCTAssertEqual(
+            endpoint,
+            "https://api-eu.mixpanel.com/record",
+            "EU record endpoint should append /record path"
+        )
+    }
+
+    func testRecordEndpointForIndiaDataResidency() {
+        let endpoint = MPSessionReplayAPI.recordEndpoint(for: MPSessionReplayAPI.inDataResidency)
+        XCTAssertEqual(
+            endpoint,
+            "https://api-in.mixpanel.com/record",
+            "India record endpoint should append /record path"
+        )
+    }
+
+    func testRecordEndpointForCustomURL() {
+        let customURL = "https://custom.example.com"
+        let endpoint = MPSessionReplayAPI.recordEndpoint(for: customURL)
+        XCTAssertEqual(
+            endpoint,
+            "https://custom.example.com/record",
+            "Custom record endpoint should append /record path"
+        )
+    }
+
+    func testRecordEndpointDefaultParameter() {
+        let endpoint = MPSessionReplayAPI.recordEndpoint()
+        XCTAssertEqual(
+            endpoint,
+            "https://api-js.mixpanel.com/record",
+            "Record endpoint should default to US data residency"
+        )
+    }
+
+    // MARK: - Settings Endpoint Tests
+
+    func testSettingsEndpointIsConstant() {
+        XCTAssertEqual(
+            MPSessionReplayAPI.settingsEndpoint,
+            "https://api.mixpanel.com/settings",
+            "Settings endpoint should be constant across all data residencies"
+        )
+    }
+
+    // MARK: - URL Format Validation
+
+    func testDataResidencyURLsDoNotContainPaths() {
+        XCTAssertFalse(
+            MPSessionReplayAPI.usDataResidency.hasSuffix("/"),
+            "US data residency URL should not end with slash"
+        )
+        XCTAssertFalse(
+            MPSessionReplayAPI.usDataResidency.contains("/record"),
+            "US data residency URL should not contain /record path"
+        )
+
+        XCTAssertFalse(
+            MPSessionReplayAPI.euDataResidency.hasSuffix("/"),
+            "EU data residency URL should not end with slash"
+        )
+        XCTAssertFalse(
+            MPSessionReplayAPI.euDataResidency.contains("/record"),
+            "EU data residency URL should not contain /record path"
+        )
+
+        XCTAssertFalse(
+            MPSessionReplayAPI.inDataResidency.hasSuffix("/"),
+            "India data residency URL should not end with slash"
+        )
+        XCTAssertFalse(
+            MPSessionReplayAPI.inDataResidency.contains("/record"),
+            "India data residency URL should not contain /record path"
+        )
+    }
+
+    func testAllDataResidencyURLsAreHTTPS() {
+        XCTAssertTrue(
+            MPSessionReplayAPI.usDataResidency.hasPrefix("https://"),
+            "US data residency should use HTTPS"
+        )
+        XCTAssertTrue(
+            MPSessionReplayAPI.euDataResidency.hasPrefix("https://"),
+            "EU data residency should use HTTPS"
+        )
+        XCTAssertTrue(
+            MPSessionReplayAPI.inDataResidency.hasPrefix("https://"),
+            "India data residency should use HTTPS"
+        )
+        XCTAssertTrue(
+            MPSessionReplayAPI.settingsEndpoint.hasPrefix("https://"),
+            "Settings endpoint should use HTTPS"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for multiple geographic data centers (US, EU, India) with string-based configuration.

## Changes

- Multi-data center support: Added `DataResidency.us`, `DataResidency.eu`, and `DataResidency.in` constants
- New config parameter: `serverURL` in `MPSessionReplayConfig` to specify data center (defaults to US)
- Moved the `Settings` endpoint to the `MPSessionReplayAPI`
- Moved `sessionReplayRedirect` to `MPSessionReplayAPI`

## API Usage

```swift
// US data center (default)
let config = MPSessionReplayConfig()

// EU data center
let config = MPSessionReplayConfig(serverURL: DataResidency.eu)

// India data center
let config = MPSessionReplayConfig(serverURL: DataResidency.in)

// Custom URL
let config = MPSessionReplayConfig(serverURL: "https://custom.host.com")
```