### PR TITLE
fix: inconsistent sdkconfig handling in ios remotesettingsmode

### DIFF
--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
@@ -155,6 +155,8 @@ class SettingsService {
                 let cachedSettings = getCachedSettingsState(token: token)
                 Logger.warn(message: "Disabled mode: Using cached setting for remote enablement switch check")
                 completion(cachedSettings, originalConfig)
+                // clear sdk_config as disabled mode shall not
+                completion(SettingsResponse.init(sdkConfig: nil, recording: cachedSettings.recording), originalConfig)
         }
     }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
@@ -155,8 +155,8 @@ class SettingsService {
                 let cachedSettings = getCachedSettingsState(token: token)
                 Logger.warn(message: "Disabled mode: Using cached setting for remote enablement switch check")
                 // Remove sdkConfig from settings response as Disabled mode does not use Remote configuration
-                let updateSettings = SettingsResponse(sdkConfig: nil, recording: cachedSettings.recording)
-                completion(updateSettings, originalConfig)
+let updatedSettings = SettingsResponse(sdkConfig: nil, recording: cachedSettings.recording)
+completion(updatedSettings, originalConfig)
         }
     }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
@@ -154,8 +154,9 @@ class SettingsService {
                 // Disabled mode: use the cached settings without merging to check remote enablement switch
                 let cachedSettings = getCachedSettingsState(token: token)
                 Logger.warn(message: "Disabled mode: Using cached setting for remote enablement switch check")
-                // clear sdk_config as disabled mode shall not
-                completion(SettingsResponse.init(sdkConfig: nil, recording: cachedSettings.recording), originalConfig)
+                // Remove sdkConfig from settings response as Disabled mode does not use Remote configuration
+                let updateSettings = SettingsResponse(sdkConfig: nil, recording: cachedSettings.recording)
+                completion(updateSettings, originalConfig)
         }
     }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
@@ -154,7 +154,6 @@ class SettingsService {
                 // Disabled mode: use the cached settings without merging to check remote enablement switch
                 let cachedSettings = getCachedSettingsState(token: token)
                 Logger.warn(message: "Disabled mode: Using cached setting for remote enablement switch check")
-                completion(cachedSettings, originalConfig)
                 // clear sdk_config as disabled mode shall not
                 completion(SettingsResponse.init(sdkConfig: nil, recording: cachedSettings.recording), originalConfig)
         }

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/SettingsService.swift
@@ -155,8 +155,8 @@ class SettingsService {
                 let cachedSettings = getCachedSettingsState(token: token)
                 Logger.warn(message: "Disabled mode: Using cached setting for remote enablement switch check")
                 // Remove sdkConfig from settings response as Disabled mode does not use Remote configuration
-let updatedSettings = SettingsResponse(sdkConfig: nil, recording: cachedSettings.recording)
-completion(updatedSettings, originalConfig)
+                let updatedSettings = SettingsResponse(sdkConfig: nil, recording: cachedSettings.recording)
+                completion(updatedSettings, originalConfig)
         }
     }
 


### PR DESCRIPTION
This pull request makes a targeted change to how the `SettingsService` handles the "Disabled mode" scenario while processing cached data. Now, when in Disabled mode, the service ensures that the cached remote SDK configuration is not included in the settings response as remote configuration is not used in this mode.
