### PR TITLE
fix: prevent event processing during exponential backoff

### DIFF
--- a/MixpanelSessionReplay/MixpanelSessionReplay/Network/FlushRequest.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Network/FlushRequest.swift
@@ -30,11 +30,6 @@ class FlushRequest {
     }
 
     func sendRequest(payloadInfo: PayloadInfo) -> Bool {
-        if requestNotAllowed() {
-            Logger.warn(message: "Request not allowed due to exponential backoff. Will retry later.")
-            return false
-        }
-
         guard let requestJSONString = MPSessionReplayEncoder.jsonPayload(payloadInfo: payloadInfo)
         else {
             return false

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Network/FlushRequest.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Network/FlushRequest.swift
@@ -107,7 +107,7 @@ class FlushRequest {
             APIConstants.maxRetryBackoff)
     }
 
-    private func requestNotAllowed() -> Bool {
+    func requestNotAllowed() -> Bool {
         let currentTime = Date().timeIntervalSince1970
         let timeRemaining = networkRequestsAllowedAfterTime - currentTime
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/FlushService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/FlushService.swift
@@ -88,7 +88,6 @@ class FlushService {
         repeat {
             // Check if we're in exponential backoff before attempting to flush
             if flushRequest.requestNotAllowed() {
-                Logger.info(message: "In exponential backoff, stopping flush batch")
                 break
             }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Services/FlushService.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Services/FlushService.swift
@@ -86,6 +86,12 @@ class FlushService {
 
     private func flushBatch(forAll: Bool) {
         repeat {
+            // Check if we're in exponential backoff before attempting to flush
+            if flushRequest.requestNotAllowed() {
+                Logger.info(message: "In exponential backoff, stopping flush batch")
+                break
+            }
+
             let events = eventService.dequeueEvents(ReplaySettings.queueBatchSize)
             guard !events.isEmpty else {
                 return

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/Network/FlushRequestTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/Network/FlushRequestTests.swift
@@ -31,20 +31,6 @@ final class FlushRequestTests: XCTestCase {
         super.tearDown()
     }
 
-    func testSendRequestNotAllowedDueToExponentialBackoff() {
-        flushRequest.networkRequestsAllowedAfterTime = Date().timeIntervalSince1970 + 1000
-        mockNetwork.sendRawRequestStub = { _ in
-            return .success((self.responseData, self.httpresponse))
-        }
-        let payloadInfo = PayloadInfo(
-            sessionEvents: [], batchStartTime: 1, seq: 1, replayId: "test", replayLengthMs: 1,
-            replayStartTime: 1)
-        let result = flushRequest.sendRequest(payloadInfo: payloadInfo)
-
-        XCTAssertFalse(result)
-        XCTAssertEqual(flushRequest.networkConsecutiveFailures, 0)
-    }
-
     func testSendRequestSuccess() {
         mockNetwork.sendRawRequestStub = { _ in
             return .success((self.responseData, self.httpresponse))
@@ -81,12 +67,7 @@ final class FlushRequestTests: XCTestCase {
             sessionEvents: [], batchStartTime: 1, seq: 1, replayId: "test", replayLengthMs: 1,
             replayStartTime: 1)
         flushRequest.networkConsecutiveFailures = 3
-        var result = flushRequest.sendRequest(payloadInfo: payloadInfo)
-        XCTAssertFalse(result)
-        XCTAssertEqual(flushRequest.networkConsecutiveFailures, 4)
-
-        // The requests are blocked for the given networkRequestsAllowedAfterTime time
-        result = flushRequest.sendRequest(payloadInfo: payloadInfo)
+        let result = flushRequest.sendRequest(payloadInfo: payloadInfo)
         XCTAssertFalse(result)
         XCTAssertEqual(flushRequest.networkConsecutiveFailures, 4)
     }


### PR DESCRIPTION
  ## Summary
  Prevents unnecessary event dequeuing and processing when the SDK is in exponential backoff state due to network failures. This aligns the iOS SDK 
  behavior with the Android SDK's more defensive approach.                                                                                         
                                                                                                                                                    
  ## Problem      
  Previously, the iOS SDK would dequeue events from the queue and attempt to build payloads even when in exponential backoff. The backoff check only
   happened inside `sendRequest()`, meaning wasted CPU cycles processing events that couldn't be sent anyway.                                       
                                                                                                                                                    
  ## Solution
  - Made `FlushRequest.requestNotAllowed()` internal (accessible to `FlushService`)                                                                 
  - Added explicit backoff check at the start of `flushBatch()` loop before dequeuing events
  - Removed redundant backoff check after failures (we already break on failure)                                                                    
                                                                                                                                                    
  ## Benefits                                                                                                                                       
  - Reduces CPU/battery usage during network outages or server failures                                                                             
  - Prevents unnecessary memory operations (dequeue/prepend)           
  - Matches Android SDK's defensive behavior                
  - Cleaner, more efficient retry logic                                                                                                             
                                                                                                                                                    
  ## Test Plan                                                                                                                                      
  - [ ] Verify flush continues normally when not in backoff                                                                                         
  - [ ] Verify flush stops immediately when in backoff (after 2+ consecutive failures)
  - [ ] Verify events remain in queue during backoff period                           
  - [ ] Verify flush resumes after backoff period expires     
  
  Fixes SDK-121