### PR TITLE
feat: mask textfields in safe views

### DIFF
--- a/MixpanelSessionReplay/MixpanelSessionReplay/Extensions/View+SensitiveView.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Extensions/View+SensitiveView.swift
@@ -74,19 +74,19 @@ struct MixpanelSensitiveWrapper<Content: View>: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIHostingController<Content> {
         let controller = UIHostingController(rootView: content)
 
-        // Set the sensitivity flag on the parent UIView for Mixpanel SDK
-        if let isSensitive = isSensitive {
-            controller.view.mpReplaySensitive = isSensitive
-        }
+        // Always set the sensitivity flag, even when nil, to prevent stale values
+        controller.view.mpReplaySensitive = isSensitive
 
         return controller
     }
 
-    /// Updates the sensitivity flag when SwiftUI state changes
+    /// Updates the content and sensitivity flag when SwiftUI state changes
     func updateUIViewController(_ uiViewController: UIHostingController<Content>, context: Context) {
-        if let isSensitive = isSensitive {
-            uiViewController.view.mpReplaySensitive = isSensitive
-        }
+        // Update content when state changes
+        uiViewController.rootView = content
+
+        // Always update sensitivity flag, even when nil, to clear previous values
+        uiViewController.view.mpReplaySensitive = isSensitive
     }
 }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Extensions/View+SensitiveView.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Extensions/View+SensitiveView.swift
@@ -47,34 +47,53 @@ extension UIView: SensitiveView {
     }
 }
 
-struct SensitiveViewWrapperRepresentable: UIViewRepresentable {
-    let onCreate: (SensitiveViewWrapper) -> Void
-
-    func makeUIView(context: Context) -> SensitiveViewWrapper {
-        let wrapper = SensitiveViewWrapper()
-        onCreate(wrapper)
-        return wrapper
-    }
-
-    func updateUIView(_ uiView: SensitiveViewWrapper, context: Context) {}
-}
-
-struct SensitiveModifier: ViewModifier {
-    let isSensitive: Bool
+struct MixpanelReplaySensitiveModifier: ViewModifier {
+    let isSensitive: Bool?
 
     func body(content: Content) -> some View {
-        content
-            .background(
-                SensitiveViewWrapperRepresentable { wrapper in
-                    wrapper.mpReplaySensitive = self.isSensitive
-                }
-            )
+        MixpanelSensitiveWrapper(isSensitive: isSensitive) {
+            content
+        }
     }
 }
 
+/// Wraps SwiftUI content in a UIHostingController to access the underlying UIView
+/// and mark it as sensitive/non-sensitive for Mixpanel session replay
+struct MixpanelSensitiveWrapper<Content: View>: UIViewControllerRepresentable {
+    /// Sensitivity flag: true = mask view, false = show view, nil = not specified
+    let isSensitive: Bool?
+    /// The SwiftUI content to wrap
+    let content: Content
+
+    init(isSensitive: Bool?, @ViewBuilder content: () -> Content) {
+        self.isSensitive = isSensitive
+        self.content = content()
+    }
+
+    /// Creates the UIHostingController and sets the sensitivity flag on its view
+    func makeUIViewController(context: Context) -> UIHostingController<Content> {
+        let controller = UIHostingController(rootView: content)
+
+        // Set the sensitivity flag on the parent UIView for Mixpanel SDK
+        if let isSensitive = isSensitive {
+            controller.view.mpReplaySensitive = isSensitive
+        }
+
+        return controller
+    }
+
+    /// Updates the sensitivity flag when SwiftUI state changes
+    func updateUIViewController(_ uiViewController: UIHostingController<Content>, context: Context) {
+        if let isSensitive = isSensitive {
+            uiViewController.view.mpReplaySensitive = isSensitive
+        }
+    }
+}
+
+// Extension to make it easy to use
 extension View {
-    public func mpReplaySensitive(_ isSensitive: Bool) -> some View {
-        self.modifier(SensitiveModifier(isSensitive: isSensitive))
+    public func mpReplaySensitive(_ isSensitive: Bool?) -> some View {
+        modifier(MixpanelReplaySensitiveModifier(isSensitive: isSensitive))
     }
 }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift
@@ -206,6 +206,7 @@ open class MPSessionReplayInstance: MPSessionReplaying {
     ///   The `recordingSessionsPercent` value from the config is ignored when calling this method.
     ///
     /// If recording is already active, calling this method has no effect.
+    /// The recording will continue until you manually stop it or until the app goes to the background, whichever happens first.
     public func startRecording(sessionsPercent: Double = 100.0) {
         /// Use main thread for all recording start setup to ensure thread safety with consistent state updates and avoid potential race conditions
         ThreadUtils.runOnMainThread { [weak self] in

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift
@@ -65,7 +65,7 @@ public struct MPSessionReplayConfig: Codable {
     /// Determines whether replay events will only be flushed to the server when the device has a WiFi connection.
     ///
     /// - When set to `true`, replay events will only be flushed to the server when the device has a WiFi connection.
-    ///   If there is no WiFi, flushes are skipped and the events remain in the in-memory queue until WiFi is restored (or until the queue reaches its limit and the oldest events are evicted to make room for newer events).
+    ///   If no WiFi is available, flushes are skipped and the events remain in memory — they will be lost if the app is terminated before WiFi becomes available.
     /// - When set to `false`, replay events will be flushed with any network connection, including cellular.
     /// - Default: `true`
     public var wifiOnly: Bool = true

--- a/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
@@ -403,6 +403,10 @@ class SensitiveViewManager {
                 var safeViewStack: [UIView] = [view]
                 while !safeViewStack.isEmpty {
                     let currentView = safeViewStack.removeLast()
+
+                    // Skip invisible views (hidden or transparent) to avoid masking visible content
+                    guard currentView.isVisible() else { continue }
+
                     if isTextField(view: currentView), let rect = hashableFrame(for: currentView.layer, in: window) {
                         addOrUpdate(&maskDecisions, rect: rect, decision: .textInput)
                     }

--- a/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
@@ -399,7 +399,16 @@ class SensitiveViewManager {
         // MARK: - Check UIView level first (UIKit + legacy SwiftUI)
         switch isSensitiveView(view: view) {
             case .safe:
-                // View is explicitly marked as safe - capture frame and stop traversal
+                // View is explicitly marked as safe - but we still need to mask textfields within it
+                var safeViewStack: [UIView] = [view]
+                while !safeViewStack.isEmpty {
+                    let currentView = safeViewStack.removeLast()
+                    if isTextField(view: currentView), let rect = hashableFrame(for: currentView.layer, in: window) {
+                        addOrUpdate(&maskDecisions, rect: rect, decision: .textInput)
+                    }
+                    safeViewStack.append(contentsOf: currentView.subviews)
+                }
+                // Capture the safe view frame
                 if let hashableRect = hashableFrame(for: view.layer, in: window) {
                     safeFrames.insert(hashableRect)
                 }

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/Extensions/ViewSensitiveViewTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/Extensions/ViewSensitiveViewTests.swift
@@ -1,0 +1,151 @@
+//
+//  ViewSensitiveViewTests.swift
+//  MixpanelSessionReplay
+//
+//  Created by Claude on 19/08/26.
+//  Copyright © 2026 Mixpanel. All rights reserved.
+//
+
+import SwiftUI
+import XCTest
+
+@testable import MixpanelSessionReplay
+
+class ViewSensitiveViewTests: XCTestCase {
+
+    // MARK: - PR #113 Tests: SwiftUI Modifier Backward Compatibility
+
+    func testMpReplaySensitive_AcceptsBoolValue() {
+        // Test that the modifier accepts Bool values (backward compatibility)
+        let view = Text("Test")
+
+        // Should compile and work with true
+        let sensitiveView = view.mpReplaySensitive(true)
+        XCTAssertNotNil(sensitiveView, "Modifier should accept Bool value 'true'")
+
+        // Should compile and work with false
+        let safeView = view.mpReplaySensitive(false)
+        XCTAssertNotNil(safeView, "Modifier should accept Bool value 'false'")
+    }
+
+    func testMpReplaySensitive_AcceptsOptionalBoolValue() {
+        // Test that the modifier accepts Bool? values (new API)
+        let view = Text("Test")
+
+        // Should work with explicit Bool? values
+        let sensitiveView = view.mpReplaySensitive(Optional(true))
+        XCTAssertNotNil(sensitiveView, "Modifier should accept Bool? value")
+
+        let safeView = view.mpReplaySensitive(Optional(false))
+        XCTAssertNotNil(safeView, "Modifier should accept Bool? value")
+
+        // Should work with nil
+        let unspecifiedView = view.mpReplaySensitive(nil)
+        XCTAssertNotNil(unspecifiedView, "Modifier should accept nil value")
+    }
+
+    func testMixpanelSensitiveWrapper_WithBoolValue() {
+        // Test the new wrapper with Bool values
+        let content = Text("Test Content")
+
+        let wrapper = MixpanelSensitiveWrapper(isSensitive: true) {
+            content
+        }
+
+        XCTAssertEqual(wrapper.isSensitive, true, "Wrapper should store Bool value as Bool?")
+    }
+
+    func testMixpanelSensitiveWrapper_WithNilValue() {
+        // Test the new wrapper with nil value
+        let content = Text("Test Content")
+
+        let wrapper = MixpanelSensitiveWrapper(isSensitive: nil) {
+            content
+        }
+
+        XCTAssertNil(wrapper.isSensitive, "Wrapper should handle nil value")
+    }
+
+    func testMixpanelSensitiveWrapper_CreatesHostingController() {
+        // Test that the wrapper creates a UIHostingController
+        let content = Text("Test Content")
+
+        let wrapper = MixpanelSensitiveWrapper(isSensitive: true) {
+            content
+        }
+
+        let context = wrapper.makeUIViewController(context: ViewControllerRepresentableContext(wrapper))
+
+        XCTAssertTrue(
+            context is UIHostingController<Text>,
+            "Should create UIHostingController")
+    }
+
+    func testMixpanelSensitiveWrapper_SetsPropertyOnView() {
+        // Test that the wrapper sets mpReplaySensitive on the view
+        let content = Text("Test Content")
+
+        let wrapper = MixpanelSensitiveWrapper(isSensitive: true) {
+            content
+        }
+
+        let controller = wrapper.makeUIViewController(
+            context: ViewControllerRepresentableContext(wrapper))
+
+        XCTAssertEqual(
+            controller.view.mpReplaySensitive, true,
+            "Should set mpReplaySensitive=true on the controller's view")
+    }
+
+    func testMixpanelSensitiveWrapper_DoesNotSetPropertyWhenNil() {
+        // Test that the wrapper doesn't set property when isSensitive is nil
+        let content = Text("Test Content")
+
+        let wrapper = MixpanelSensitiveWrapper(isSensitive: nil) {
+            content
+        }
+
+        let controller = wrapper.makeUIViewController(
+            context: ViewControllerRepresentableContext(wrapper))
+
+        XCTAssertNil(
+            controller.view.mpReplaySensitive,
+            "Should not set mpReplaySensitive when isSensitive is nil")
+    }
+
+    func testMixpanelSensitiveWrapper_UpdatesPropertyOnChange() {
+        // Test that the wrapper updates the property when state changes
+        let content = Text("Test Content")
+
+        let wrapper = MixpanelSensitiveWrapper(isSensitive: false) {
+            content
+        }
+
+        let controller = wrapper.makeUIViewController(
+            context: ViewControllerRepresentableContext(wrapper))
+
+        XCTAssertEqual(
+            controller.view.mpReplaySensitive, false,
+            "Initial value should be false")
+
+        // Simulate update
+        let updatedWrapper = MixpanelSensitiveWrapper(isSensitive: true) {
+            content
+        }
+
+        updatedWrapper.updateUIViewController(
+            controller,
+            context: ViewControllerRepresentableContext(updatedWrapper))
+
+        XCTAssertEqual(
+            controller.view.mpReplaySensitive, true,
+            "Should update to true after updateUIViewController")
+    }
+}
+
+// Helper to create ViewControllerRepresentableContext for testing
+extension ViewControllerRepresentableContext {
+    init(_ representable: Representable) {
+        self.init(representable, coordinator: representable.makeCoordinator())
+    }
+}

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/Extensions/ViewSensitiveViewTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/Extensions/ViewSensitiveViewTests.swift
@@ -141,6 +141,36 @@ class ViewSensitiveViewTests: XCTestCase {
             controller.view.mpReplaySensitive, true,
             "Should update to true after updateUIViewController")
     }
+
+    func testMixpanelSensitiveWrapper_ClearsPropertyWhenNil() {
+        // Test that the wrapper clears the property when isSensitive becomes nil
+        let content = Text("Test Content")
+
+        // Start with true
+        let wrapper1 = MixpanelSensitiveWrapper(isSensitive: true) {
+            content
+        }
+
+        let controller = wrapper1.makeUIViewController(
+            context: ViewControllerRepresentableContext(wrapper1))
+
+        XCTAssertEqual(
+            controller.view.mpReplaySensitive, true,
+            "Initial value should be true")
+
+        // Update to nil - should clear the property
+        let wrapper2 = MixpanelSensitiveWrapper(isSensitive: nil) {
+            content
+        }
+
+        wrapper2.updateUIViewController(
+            controller,
+            context: ViewControllerRepresentableContext(wrapper2))
+
+        XCTAssertNil(
+            controller.view.mpReplaySensitive,
+            "Property should be cleared when isSensitive becomes nil")
+    }
 }
 
 // Helper to create ViewControllerRepresentableContext for testing

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/SensitiveViews/SensitiveViewManagerTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/SensitiveViews/SensitiveViewManagerTests.swift
@@ -702,4 +702,43 @@ class SensitiveViewManagerTests: BaseTests {
             sensitiveFrames[HashableRect(sensitiveView.frame)], .mask,
             "Explicitly sensitive view should be masked as .mask")
     }
+
+    func testSafeView_InvisibleTextFieldsNotMasked() {
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        let window = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+
+        // Safe container
+        let safeContainer = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        safeContainer.mpReplaySensitive = false
+        rootView.addSubview(safeContainer)
+
+        // Hidden textfield (should NOT be masked)
+        let hiddenTextField = UITextField(frame: CGRect(x: 10, y: 10, width: 80, height: 30))
+        hiddenTextField.isHidden = true
+        safeContainer.addSubview(hiddenTextField)
+
+        // Transparent textfield (should NOT be masked)
+        let transparentTextField = UITextField(frame: CGRect(x: 10, y: 50, width: 80, height: 30))
+        transparentTextField.alpha = 0
+        safeContainer.addSubview(transparentTextField)
+
+        // Visible textfield (should be masked)
+        let visibleTextField = UITextField(frame: CGRect(x: 10, y: 90, width: 80, height: 30))
+        safeContainer.addSubview(visibleTextField)
+
+        let sensitiveFrames = manager.getSensitiveFrames(in: rootView, window: window)
+
+        // Hidden and transparent textfields should NOT be in sensitive frames
+        XCTAssertNil(
+            sensitiveFrames[HashableRect(hiddenTextField.frame)],
+            "Hidden textfield should not be masked")
+        XCTAssertNil(
+            sensitiveFrames[HashableRect(transparentTextField.frame)],
+            "Transparent textfield should not be masked")
+
+        // Visible textfield SHOULD be masked
+        XCTAssertEqual(
+            sensitiveFrames[HashableRect(visibleTextField.frame)], .textInput,
+            "Visible textfield should be masked")
+    }
 }

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/SensitiveViews/SensitiveViewManagerTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/SensitiveViews/SensitiveViewManagerTests.swift
@@ -537,4 +537,169 @@ class SensitiveViewManagerTests: BaseTests {
                 + "SwiftUI may have renamed/removed CGDrawingLayer in this iOS version — "
         )
     }
+
+    // MARK: - PR #113 Tests: TextField Masking in Safe Views
+
+    func testTextFieldInSafeView_IsMasked() {
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        let window = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+
+        // Create a container marked as safe
+        let safeContainer = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        safeContainer.mpReplaySensitive = false
+        rootView.addSubview(safeContainer)
+
+        // Add a textfield inside the safe container
+        let textField = UITextField(frame: CGRect(x: 10, y: 10, width: 80, height: 30))
+        safeContainer.addSubview(textField)
+
+        // Add a regular label inside safe container (should not be masked)
+        let label = UILabel(frame: CGRect(x: 10, y: 50, width: 80, height: 20))
+        safeContainer.addSubview(label)
+
+        manager.maskAllText = true
+        let sensitiveFrames = manager.getSensitiveFrames(in: rootView, window: window)
+
+        // The textfield should be masked even though its parent is safe
+        XCTAssertEqual(
+            sensitiveFrames[HashableRect(textField.frame)], .textInput,
+            "TextField inside safe container should still be masked as textInput")
+
+        // The label should not be masked (parent is safe)
+        XCTAssertNil(
+            sensitiveFrames[HashableRect(label.frame)],
+            "Label inside safe container should not be masked")
+    }
+
+    func testNestedTextFieldsInSafeView_AllMasked() {
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
+        let window = UIView(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
+
+        // Create a safe container
+        let safeContainer = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        safeContainer.mpReplaySensitive = false
+        rootView.addSubview(safeContainer)
+
+        // Add a nested container inside safe view
+        let nestedContainer = UIView(frame: CGRect(x: 10, y: 10, width: 180, height: 180))
+        safeContainer.addSubview(nestedContainer)
+
+        // Add textfield at level 1 (direct child of safe view)
+        let textField1 = UITextField(frame: CGRect(x: 10, y: 10, width: 80, height: 30))
+        safeContainer.addSubview(textField1)
+
+        // Add textfield at level 2 (nested inside another view)
+        let textField2 = UITextField(frame: CGRect(x: 10, y: 10, width: 80, height: 30))
+        nestedContainer.addSubview(textField2)
+
+        // Add deeply nested textfield at level 3
+        let deepContainer = UIView(frame: CGRect(x: 10, y: 50, width: 160, height: 120))
+        nestedContainer.addSubview(deepContainer)
+        let textField3 = UITextField(frame: CGRect(x: 10, y: 10, width: 80, height: 30))
+        deepContainer.addSubview(textField3)
+
+        let sensitiveFrames = manager.getSensitiveFrames(in: rootView, window: window)
+
+        // All textfields should be masked via stack-based traversal
+        XCTAssertEqual(
+            sensitiveFrames[HashableRect(textField1.frame)], .textInput,
+            "TextField at level 1 should be masked")
+        XCTAssertEqual(
+            sensitiveFrames[HashableRect(textField2.frame)], .textInput,
+            "TextField at level 2 should be masked")
+        XCTAssertEqual(
+            sensitiveFrames[HashableRect(textField3.frame)], .textInput,
+            "Deeply nested textfield at level 3 should be masked")
+    }
+
+    func testSafeView_WithoutTextFields_BehavesNormally() {
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        let window = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+
+        // Create a safe container with no textfields
+        let safeContainer = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        safeContainer.mpReplaySensitive = false
+        rootView.addSubview(safeContainer)
+
+        // Add regular views inside (should not be masked)
+        let label = UILabel(frame: CGRect(x: 10, y: 10, width: 80, height: 20))
+        safeContainer.addSubview(label)
+
+        let imageView = UIImageView(frame: CGRect(x: 10, y: 40, width: 80, height: 40))
+        safeContainer.addSubview(imageView)
+
+        manager.maskAllText = true
+        manager.maskAllImages = true
+        let sensitiveFrames = manager.getSensitiveFrames(in: rootView, window: window)
+
+        // Nothing should be masked (all inside safe container, no textfields)
+        XCTAssertNil(
+            sensitiveFrames[HashableRect(label.frame)],
+            "Label inside safe container should not be masked")
+        XCTAssertNil(
+            sensitiveFrames[HashableRect(imageView.frame)],
+            "ImageView inside safe container should not be masked")
+    }
+
+    func testMultipleSafeViews_WithTextFields() {
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 300, height: 200))
+        let window = UIView(frame: CGRect(x: 0, y: 0, width: 300, height: 200))
+
+        // First safe container with textfield
+        let safeContainer1 = UIView(frame: CGRect(x: 0, y: 0, width: 140, height: 100))
+        safeContainer1.mpReplaySensitive = false
+        rootView.addSubview(safeContainer1)
+
+        let textField1 = UITextField(frame: CGRect(x: 10, y: 10, width: 120, height: 30))
+        safeContainer1.addSubview(textField1)
+
+        // Second safe container with textfield
+        let safeContainer2 = UIView(frame: CGRect(x: 150, y: 0, width: 140, height: 100))
+        safeContainer2.mpReplaySensitive = false
+        rootView.addSubview(safeContainer2)
+
+        let textField2 = UITextField(frame: CGRect(x: 10, y: 10, width: 120, height: 30))
+        safeContainer2.addSubview(textField2)
+
+        let sensitiveFrames = manager.getSensitiveFrames(in: rootView, window: window)
+
+        // Both textfields should be masked
+        XCTAssertEqual(
+            sensitiveFrames[HashableRect(textField1.frame)], .textInput,
+            "TextField in first safe container should be masked")
+        XCTAssertEqual(
+            sensitiveFrames[HashableRect(textField2.frame)], .textInput,
+            "TextField in second safe container should be masked")
+    }
+
+    func testSafeViewWithTextFieldAndSensitiveView_BothHandledCorrectly() {
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        let window = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+
+        // Safe container
+        let safeContainer = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        safeContainer.mpReplaySensitive = false
+        rootView.addSubview(safeContainer)
+
+        // Textfield inside safe view (should be masked)
+        let textField = UITextField(frame: CGRect(x: 10, y: 10, width: 80, height: 30))
+        safeContainer.addSubview(textField)
+
+        // Regular sensitive view outside safe container (should be masked)
+        let sensitiveView = UIView(frame: CGRect(x: 120, y: 10, width: 70, height: 70))
+        sensitiveView.mpReplaySensitive = true
+        rootView.addSubview(sensitiveView)
+
+        let sensitiveFrames = manager.getSensitiveFrames(in: rootView, window: window)
+
+        // TextField should be masked
+        XCTAssertEqual(
+            sensitiveFrames[HashableRect(textField.frame)], .textInput,
+            "TextField inside safe container should be masked")
+
+        // Sensitive view should be masked
+        XCTAssertEqual(
+            sensitiveFrames[HashableRect(sensitiveView.frame)], .mask,
+            "Explicitly sensitive view should be masked as .mask")
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a security issue where textfields within views marked as safe using `mpReplaySensitive(false)` were not being masked. This ensures textfields are always masked by default, even when their parent view is marked as safe.

## Changes

### SwiftUI Integration Refactoring
- **Replaced** `SensitiveViewWrapperRepresentable` with `MixpanelSensitiveWrapper<Content: View>: UIViewControllerRepresentable`
  - Old approach: Used `UIViewRepresentable` with a wrapper view
  - New approach: Uses `UIViewControllerRepresentable` with `UIHostingController` for proper parent-child view hierarchy
- **Replaced** `SensitiveModifier` with `MixpanelReplaySensitiveModifier`
- **Updated** `mpReplaySensitive()` API signature from `Bool` to `Bool?` (backward compatible)

### Safe View Traversal Enhancement
- Added stack-based traversal to find and mask textfields within safe views

### Documentation Updates
- Clarified `startRecording()` lifecycle behavior
- Updated `wifiOnly` property documentation

## Why UIHostingController?

The old approach created a sibling relationship; the new approach creates a parent-child relationship, enabling traversal into SwiftUI content to find textfields.

## Test Coverage

- ✅ Textfield masking inside safe views
- ✅ Nested textfield detection
- ✅ Backward compatibility
- ✅ UIHostingController integration

## Breaking Changes

**Behavioral change:** Textfields in safe views will now be masked (intentional security fix).

Fixes SDK-19

🤖 Generated with [Claude Code](https://claude.ai/claude-code)