### PR TITLE
feat: mask editable UITextViews as text inputs 

### DIFF
--- a/MixpanelSessionReplay/MixpanelSessionReplay/Extensions/View+SensitiveView.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Extensions/View+SensitiveView.swift
@@ -76,7 +76,12 @@ struct MixpanelSensitiveWrapper<Content: View>: UIViewControllerRepresentable {
 
         // Always set the sensitivity flag, even when nil, to prevent stale values
         controller.view.mpReplaySensitive = isSensitive
-
+        // iOS 15 and below: disable autoresizing to respect SwiftUI layout
+        if #available(iOS 16.0, *) {
+            // sizeThatFits will handle sizing
+        } else {
+            controller.view.translatesAutoresizingMaskIntoConstraints = false
+        }
         return controller
     }
 
@@ -87,6 +92,17 @@ struct MixpanelSensitiveWrapper<Content: View>: UIViewControllerRepresentable {
 
         // Always update sensitivity flag, even when nil, to clear previous values
         uiViewController.view.mpReplaySensitive = isSensitive
+    }
+
+    @available(iOS 16.0, *)
+    func sizeThatFits(_ proposal: ProposedViewSize, uiViewController: UIHostingController<Content>, context: Context)
+        -> CGSize?
+    {
+        return uiViewController.sizeThatFits(
+            in: CGSize(
+                width: proposal.width ?? .infinity,
+                height: proposal.height ?? .infinity
+            ))
     }
 }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
@@ -218,11 +218,6 @@ class SensitiveViewManager {
             return true
         }
 
-        // Check if the textView is non-editable, then consider as label
-        if view.isKind(of: UITextView.self), let textView = view as? UITextView, !textView.isEditable {
-            return true
-        }
-
         // Legacy: SwiftUI CGDrawingView (iOS 18 and earlier)
         if let swiftUiTextClass, type(of: view) == swiftUiTextClass {
             return true
@@ -251,7 +246,7 @@ class SensitiveViewManager {
         }
 
         // Check if the textView is editable, then consider as textInput
-        if view.isKind(of: UITextView.self), let textView = view as? UITextView, textView.isEditable {
+        if view.isKind(of: UITextView.self), let textView = view as? UITextView {
             return true
         }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
@@ -173,7 +173,7 @@ class SensitiveViewManager {
             return .sensitive
         }
 
-        // Text inputs (textfields and editable textviews) are always sensitive, so check before !isSensitive
+        // Text inputs (UITextField / UITextView) are always sensitive, so check before !isSensitive
         if isTextInput(view: view) {
             sensitiveTextInputViews.insert(view)
             return .sensitiveTextField

--- a/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
@@ -105,7 +105,7 @@ class SensitiveViewManager {
     var sensitiveClasses: [AnyClass] = []
 
     private(set) var knownSensitiveViews: WeakViewsMap!
-    var sensitiveTextFieldViews: WeakViewsMap!
+    var sensitiveTextInputViews: WeakViewsMap!
     var sensitiveClassViews: WeakViewsMap!
 
     // MARK: Liquid glass UI unaffected SwiftUI Classes
@@ -145,7 +145,7 @@ class SensitiveViewManager {
 
         knownSensitiveViews = WeakViewsMap.weakToWeakObjects()
         sensitiveClassViews = WeakViewsMap.weakToWeakObjects()
-        sensitiveTextFieldViews = WeakViewsMap.weakToWeakObjects()
+        sensitiveTextInputViews = WeakViewsMap.weakToWeakObjects()
         swiftUIiOS26TextLayerClass = ObfuscatedClassLookup.resolveClass(from: swiftUIDrawingLayerCodes)
     }
 
@@ -156,7 +156,7 @@ class SensitiveViewManager {
     func clearCache() {
         knownSensitiveViews.removeAllObjects()
         sensitiveClassViews.removeAllObjects()
-        sensitiveTextFieldViews.removeAllObjects()
+        sensitiveTextInputViews.removeAllObjects()
     }
 
     func isSensitiveView(view: UIView) -> SensitiveViewState {
@@ -164,8 +164,8 @@ class SensitiveViewManager {
             return .sensitive
         }
 
-        // Check text field cache first to maintain .sensitiveTextField return type
-        if sensitiveTextFieldViews.contains(view) {
+        // Check text input cache first to maintain .sensitiveTextField return type
+        if sensitiveTextInputViews.contains(view) {
             return .sensitiveTextField
         }
 
@@ -173,9 +173,9 @@ class SensitiveViewManager {
             return .sensitive
         }
 
-        // Text fields are always sensitive, so check before !isSensitive
-        if isTextField(view: view) {
-            sensitiveTextFieldViews.insert(view)
+        // Text inputs (textfields and editable textviews) are always sensitive, so check before !isSensitive
+        if isTextInput(view: view) {
+            sensitiveTextInputViews.insert(view)
             return .sensitiveTextField
         }
 
@@ -214,7 +214,12 @@ class SensitiveViewManager {
 
     // Legacy text/label detection
     func isLabel(view: UIView) -> Bool {
-        if view.isKind(of: UILabel.self) || view.isKind(of: UITextView.self) {
+        if view.isKind(of: UILabel.self) {
+            return true
+        }
+
+        // Check if the textView is non-editable, then consider as label
+        if view.isKind(of: UITextView.self), let textView = view as? UITextView, !textView.isEditable {
             return true
         }
 
@@ -240,8 +245,13 @@ class SensitiveViewManager {
         return false
     }
 
-    func isTextField(view: UIView) -> Bool {
+    func isTextInput(view: UIView) -> Bool {
         if view.isKind(of: UITextField.self) {
+            return true
+        }
+
+        // Check if the textView is editable, then consider as textInput
+        if view.isKind(of: UITextView.self), let textView = view as? UITextView, textView.isEditable {
             return true
         }
 
@@ -399,7 +409,9 @@ class SensitiveViewManager {
         // MARK: - Check UIView level first (UIKit + legacy SwiftUI)
         switch isSensitiveView(view: view) {
             case .safe:
-                // View is explicitly marked as safe - but we still need to mask textfields within it
+                // View is explicitly marked as safe - but we still need to mask text inputs within it
+                // Check if text input (textfield or editable textview) is present inside a view that is marked as safe,
+                // if found, mask the text input
                 var safeViewStack: [UIView] = [view]
                 while !safeViewStack.isEmpty {
                     let currentView = safeViewStack.removeLast()
@@ -407,7 +419,7 @@ class SensitiveViewManager {
                     // Skip invisible views (hidden or transparent) to avoid masking visible content
                     guard currentView.isVisible() else { continue }
 
-                    if isTextField(view: currentView), let rect = hashableFrame(for: currentView.layer, in: window) {
+                    if isTextInput(view: currentView), let rect = hashableFrame(for: currentView.layer, in: window) {
                         addOrUpdate(&maskDecisions, rect: rect, decision: .textInput)
                     }
                     safeViewStack.append(contentsOf: currentView.subviews)
@@ -419,7 +431,7 @@ class SensitiveViewManager {
                 return  // Don't process subviews or sublayers
 
             case .sensitiveTextField:
-                // Text fields are always sensitive and cannot be overridden by safe parents
+                // Text inputs (textfields/editable textviews) are always sensitive and cannot be overridden by safe parents
                 if let hashableRect = hashableFrame(for: view.layer, in: window) {
                     addOrUpdate(&maskDecisions, rect: hashableRect, decision: .textInput)
                 }

--- a/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
@@ -241,12 +241,7 @@ class SensitiveViewManager {
     }
 
     func isTextInput(view: UIView) -> Bool {
-        if view.isKind(of: UITextField.self) {
-            return true
-        }
-
-        // Check if the textView is editable, then consider as textInput
-        if view.isKind(of: UITextView.self), let textView = view as? UITextView {
+        if view.isKind(of: UITextField.self) || view.isKind(of: UITextView.self) {
             return true
         }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/MPSessionReplayAutoMaskedViewsTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/MPSessionReplayAutoMaskedViewsTests.swift
@@ -118,11 +118,11 @@ class MPSessionReplayAutoMaskedViewsTests: BaseTests {
 
         SensitiveViewManager.shared.knownSensitiveViews.insert(label)
         SensitiveViewManager.shared.knownSensitiveViews.insert(imageView)
-        SensitiveViewManager.shared.sensitiveTextFieldViews.insert(textField)
+        SensitiveViewManager.shared.sensitiveTextInputViews.insert(textField)
         SensitiveViewManager.shared.sensitiveClassViews.insert(customView)
 
         XCTAssertTrue(SensitiveViewManager.shared.knownSensitiveViews.contains(label))
-        XCTAssertTrue(SensitiveViewManager.shared.sensitiveTextFieldViews.contains(textField))
+        XCTAssertTrue(SensitiveViewManager.shared.sensitiveTextInputViews.contains(textField))
         XCTAssertTrue(SensitiveViewManager.shared.sensitiveClassViews.contains(customView))
 
         // Update masking - should clear all caches
@@ -137,7 +137,7 @@ class MPSessionReplayAutoMaskedViewsTests: BaseTests {
 
         XCTAssertFalse(SensitiveViewManager.shared.knownSensitiveViews.contains(label))
         XCTAssertFalse(SensitiveViewManager.shared.knownSensitiveViews.contains(imageView))
-        XCTAssertFalse(SensitiveViewManager.shared.sensitiveTextFieldViews.contains(textField))
+        XCTAssertFalse(SensitiveViewManager.shared.sensitiveTextInputViews.contains(textField))
         XCTAssertFalse(SensitiveViewManager.shared.sensitiveClassViews.contains(customView))
     }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/SensitiveViews/SensitiveViewManagerTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/SensitiveViews/SensitiveViewManagerTests.swift
@@ -52,7 +52,7 @@ class SensitiveViewManagerTests: BaseTests {
         let result = manager.isSensitiveView(view: textView)
         XCTAssertEqual(
             result, .sensitiveTextField,
-            "Non-editable UITextView should be detected as sensitive (like a label) when maskAllText is enabled")
+            "Non-editable UITextView should still be masked as text input for security (conservative approach)")
     }
 
     func testSensitiveViewDetection_ImageView() {

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/SensitiveViews/SensitiveViewManagerTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/SensitiveViews/SensitiveViewManagerTests.swift
@@ -51,7 +51,7 @@ class SensitiveViewManagerTests: BaseTests {
         textView.isEditable = false
         let result = manager.isSensitiveView(view: textView)
         XCTAssertEqual(
-            result, .sensitive,
+            result, .sensitiveTextField,
             "Non-editable UITextView should be detected as sensitive (like a label) when maskAllText is enabled")
     }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplayTests/SensitiveViews/SensitiveViewManagerTests.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplayTests/SensitiveViews/SensitiveViewManagerTests.swift
@@ -32,11 +32,27 @@ class SensitiveViewManagerTests: BaseTests {
         XCTAssertEqual(result, .sensitiveTextField, "UITextField should be detected as sensitiveTextField")
     }
 
+    func testSensitiveViewDetection_EditableTextView() {
+        let textView = UITextView()
+        textView.isEditable = true
+        let result = manager.isSensitiveView(view: textView)
+        XCTAssertEqual(result, .sensitiveTextField, "Editable UITextView should be detected as sensitiveTextField")
+    }
+
     func testSensitiveViewDetection_Label() {
         let label = UILabel()
         let result = manager.isSensitiveView(view: label)
         XCTAssertEqual(
             result, .sensitive, "UILabel should be detected as sensitive when maskAllText is enabled")
+    }
+
+    func testSensitiveViewDetection_NonEditableTextView() {
+        let textView = UITextView()
+        textView.isEditable = false
+        let result = manager.isSensitiveView(view: textView)
+        XCTAssertEqual(
+            result, .sensitive,
+            "Non-editable UITextView should be detected as sensitive (like a label) when maskAllText is enabled")
     }
 
     func testSensitiveViewDetection_ImageView() {
@@ -164,11 +180,11 @@ class SensitiveViewManagerTests: BaseTests {
 
         manager.knownSensitiveViews.insert(label)
         manager.sensitiveClassViews.insert(customView)
-        manager.sensitiveTextFieldViews.insert(textField)
+        manager.sensitiveTextInputViews.insert(textField)
 
         XCTAssertTrue(manager.knownSensitiveViews.contains(label))
         XCTAssertTrue(manager.sensitiveClassViews.contains(customView))
-        XCTAssertTrue(manager.sensitiveTextFieldViews.contains(textField))
+        XCTAssertTrue(manager.sensitiveTextInputViews.contains(textField))
 
         // Clear cache
         manager.clearCache()
@@ -176,7 +192,7 @@ class SensitiveViewManagerTests: BaseTests {
         // Verify all caches are cleared
         XCTAssertFalse(manager.knownSensitiveViews.contains(label))
         XCTAssertFalse(manager.sensitiveClassViews.contains(customView))
-        XCTAssertFalse(manager.sensitiveTextFieldViews.contains(textField))
+        XCTAssertFalse(manager.sensitiveTextInputViews.contains(textField))
     }
 
     func testSensitiveViewDetection_TextField_ReturnsSensitiveTextField() {


### PR DESCRIPTION
## Summary

Extends text input masking to **all UITextViews** regardless of their `isEditable` state. This is a conservative security approach that treats all UITextViews as potential user input fields.

## Decision: No `isEditable` Distinction

**All UITextViews are now always masked**, regardless of whether they're editable or not.

### Why This Approach?

✅ **Maximum security:** Prevents any UITextView content from being exposed
✅ **State independence:** `isEditable` can change at runtime
✅ **Conservative by default:** Better to over-mask than under-mask
✅ **Simpler logic:** No conditional checks based on mutable state

## Changes

### 1. Renamed for Clarity
- `sensitiveTextFieldViews` → `sensitiveTextInputViews`
- `isTextField()` → `isTextInput()`
- Updated all comments to reflect "text input" terminology

### 2. Enhanced Detection Logic

**`isTextInput()` now detects:**
- ✅ `UITextField` (as before)
- ✅ **All `UITextView` instances** (new - no `isEditable` check)
- ✅ SwiftUI `TextEditorTextView`

**`isLabel()` updated:**
- ✅ `UILabel` only
- ❌ `UITextView` **removed** - no longer treated
- ✅ Legacy SwiftUI text views

## Use Cases Covered

This ensures all potential text input scenarios are masked:
- Password fields
- Multi-line text input
- Comment boxes
- Rich text editors
- **Read-only text displays** (conservative appro

## Test Coverage

✅ All UITextViews detected as text inputs
✅ Editable UITextViews masked
✅ **Non-editable UITextViews also masked** (secu
✅ UILabels still handled separately

## Stacked On

This PR is **stacked on top of** the base PR (`mask-textfields-from-safe-views`). Merge that one first, then this can be rebased to `main`.

Fixes SDK-18

---

🤖 Generated with [Claude Code](https://claude.ai