### PR TITLE
fix: Parent-Based Detection via Sibling Approach to traverse the safe views

### DIFF
--- a/MixpanelSessionReplay/MixpanelSessionReplay/Extensions/View+SensitiveView.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Extensions/View+SensitiveView.swift
@@ -53,6 +53,10 @@ struct MixpanelSensitiveMarker: UIViewRepresentable {
     /// Sensitivity flag: true = mask view, false = show view, nil = not specified
     let isSensitive: Bool?
 
+    func makeCoordinator() -> MarkerState {
+        MarkerState()
+    }
+
     func makeUIView(context: Context) -> UIView {
         let marker = UIView(frame: .zero)
         marker.isHidden = true  // Invisible - doesn't affect layout or rendering
@@ -61,11 +65,32 @@ struct MixpanelSensitiveMarker: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {
-        // Mark the parent view (which contains both the marker and actual content)
-        // This allows traversal into the content's children normally
-        DispatchQueue.main.async {
-            uiView.superview?.mpReplaySensitive = isSensitive
+        let state = context.coordinator
+
+        // Clear previous parent if it changed (prevents stale metadata)
+        if let previousParent = state.markedParent, previousParent !== uiView.superview {
+            previousParent.mpReplaySensitive = nil
         }
+
+        // Mark the current parent view (which contains both the marker and actual content)
+        // This allows traversal into the content's children normally
+        uiView.superview?.mpReplaySensitive = isSensitive
+
+        // Track the parent we just marked for future cleanup
+        state.markedParent = uiView.superview
+    }
+
+    static func dismantleUIView(_ uiView: UIView, coordinator: MarkerState) {
+        // Clean up: clear the sensitivity flag when marker is removed
+        // This prevents stale metadata when views are conditionally shown/hidden
+        coordinator.markedParent?.mpReplaySensitive = nil
+        coordinator.markedParent = nil
+    }
+
+    /// Tracks the parent view that has been marked with sensitivity metadata
+    /// Used for cleanup when the marker is removed or moves to a different parent
+    class MarkerState {
+        weak var markedParent: UIView?
     }
 }
 
@@ -82,8 +107,6 @@ extension View {
         modifier(MixpanelReplaySensitiveModifier(isSensitive: isSensitive))
     }
 }
-
-class SensitiveViewWrapper: UIView {}
 
 private var mpReplaySensitiveKey: UInt8 = 0
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/Extensions/View+SensitiveView.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/Extensions/View+SensitiveView.swift
@@ -47,34 +47,39 @@ extension UIView: SensitiveView {
     }
 }
 
-struct SensitiveViewWrapperRepresentable: UIViewRepresentable {
-    let onCreate: (SensitiveViewWrapper) -> Void
+/// Creates an invisible marker view as a sibling to mark the parent view as sensitive/safe
+/// Uses .background() to create a sibling relationship without wrapping or affecting layout
+struct MixpanelSensitiveMarker: UIViewRepresentable {
+    /// Sensitivity flag: true = mask view, false = show view, nil = not specified
+    let isSensitive: Bool?
 
-    func makeUIView(context: Context) -> SensitiveViewWrapper {
-        let wrapper = SensitiveViewWrapper()
-        onCreate(wrapper)
-        return wrapper
+    func makeUIView(context: Context) -> UIView {
+        let marker = UIView(frame: .zero)
+        marker.isHidden = true  // Invisible - doesn't affect layout or rendering
+        marker.isUserInteractionEnabled = false  // Doesn't intercept touches
+        return marker
     }
 
-    func updateUIView(_ uiView: SensitiveViewWrapper, context: Context) {}
+    func updateUIView(_ uiView: UIView, context: Context) {
+        // Mark the parent view (which contains both the marker and actual content)
+        // This allows traversal into the content's children normally
+        DispatchQueue.main.async {
+            uiView.superview?.mpReplaySensitive = isSensitive
+        }
+    }
 }
 
-struct SensitiveModifier: ViewModifier {
-    let isSensitive: Bool
+struct MixpanelReplaySensitiveModifier: ViewModifier {
+    let isSensitive: Bool?
 
     func body(content: Content) -> some View {
-        content
-            .background(
-                SensitiveViewWrapperRepresentable { wrapper in
-                    wrapper.mpReplaySensitive = self.isSensitive
-                }
-            )
+        content.background(MixpanelSensitiveMarker(isSensitive: isSensitive))
     }
 }
 
 extension View {
-    public func mpReplaySensitive(_ isSensitive: Bool) -> some View {
-        self.modifier(SensitiveModifier(isSensitive: isSensitive))
+    public func mpReplaySensitive(_ isSensitive: Bool?) -> some View {
+        modifier(MixpanelReplaySensitiveModifier(isSensitive: isSensitive))
     }
 }
 

--- a/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
+++ b/MixpanelSessionReplay/MixpanelSessionReplay/SensitiveViews/SensitiveViewManager.swift
@@ -399,7 +399,20 @@ class SensitiveViewManager {
         // MARK: - Check UIView level first (UIKit + legacy SwiftUI)
         switch isSensitiveView(view: view) {
             case .safe:
-                // View is explicitly marked as safe - capture frame and stop traversal
+                // View is explicitly marked as safe - but we still need to mask textfields within it
+                var safeViewStack: [UIView] = [view]
+                while !safeViewStack.isEmpty {
+                    let currentView = safeViewStack.removeLast()
+
+                    // Skip invisible views (hidden or transparent) to avoid masking visible content
+                    guard currentView.isVisible() else { continue }
+
+                    if isTextField(view: currentView), let rect = hashableFrame(for: currentView.layer, in: window) {
+                        addOrUpdate(&maskDecisions, rect: rect, decision: .textInput)
+                    }
+                    safeViewStack.append(contentsOf: currentView.subviews)
+                }
+                // Capture the safe view frame
                 if let hashableRect = hashableFrame(for: view.layer, in: window) {
                     safeFrames.insert(hashableRect)
                 }


### PR DESCRIPTION
Summary

Implements a non-invasive approach for marking SwiftUI views as sensitive/safe for session replay. Uses an invisible marker view created via .background() that marks its parent container, enabling proper view hierarchy traversal without layout interference.

Changes

MixpanelSessionReplay/Extensions/View+SensitiveView.swift

Replaced UIHostingController wrapper with sibling marker approach:

1. MixpanelSensitiveMarker (UIViewRepresentable)
   - Creates invisible marker view (hidden, zero-frame, no user interaction)
   - Marks parent container via superview.mpReplaySensitive = isSensitive
   - Uses DispatchQueue.main.async to ensure view hierarchy is ready
2. Updated API to support Bool?
   - mpReplaySensitive(_ isSensitive: Bool?) now accepts true, false, or nil
   - Allows clearing sensitivity state (important for preventing stale metadata)
3. How it works:
VStack {
    TextField("Username", text: $username)
}
.mpReplaySensitive(false)  // Marks parent container as safe

   View hierarchy created:
SwiftUI Container (mpReplaySensitive = false)
├── Marker view (hidden)
└── VStack content
    └── TextField ← Found via traversal

Benefits

✅ No layout issues - Marker is invisible (hidden, zero-size)
✅ No UIHostingController overhead - Direct UIViewRepresentable
✅ Enables traversal - Parent contains all content as descendants
✅ Non-invasive - Doesn't wrap or interfere with SwiftUI rendering
✅ Backward compatible - Supports both Bool and Bool?

How Traversal Works

1. SensitiveViewManager traverses UIKit hierarchy
2. Finds parent container with mpReplaySensitive = false (safe)
3. Enters safe-view traversal mode
4. Discovers TextField as descendant and masks it as text input
5. Does NOT mask the safe container itself

Use Cases

Mark entire forms as safe (mask only text inputs):
```
VStack {
    Text("Login")
    TextField("Email", text: $email)
    SecureField("Password", text: $password)
}
.mpReplaySensitive(false)
```

Mark sensitive content (mask entire container):
```
VStack {
    Text("SSN: \(ssn)")
    Text("Credit Card: \(card)")
}
.mpReplaySensitive(true)
```

Technical Details

- Marker uses .background() to create sibling relationship
- Parent marking happens in updateUIView() to ensure hierarchy exists
- Async dispatch ensures superview is available when marked
- Supports nil to clear previous sensitivity values
